### PR TITLE
Gooliajulia/create profile

### DIFF
--- a/backend/models/user.js
+++ b/backend/models/user.js
@@ -18,6 +18,7 @@ const User = new Schema(
     password_digest: { type: String, required: true, select: false },
     portfolio_projects: [{ type: Object }],
     portfolio_link: { type: String },
+    show_portfolio: { type: Boolean },
     rejected_projects: [{ type: Schema.Types.ObjectId, ref: "Project" }],
     role: { type: String, enum: ["Software Engineer", "UX Designer"] },
   },

--- a/native/components/Button/SingleActionButton.jsx
+++ b/native/components/Button/SingleActionButton.jsx
@@ -25,6 +25,10 @@ export const SingleActionButton = ({ payload }) => {
     // then reroutes
   };
 
+  const triggerAlert = () => {
+    
+  }
+
   switch (type) {
     case 'reroute':
       return (

--- a/native/components/Button/SingleActionButton.jsx
+++ b/native/components/Button/SingleActionButton.jsx
@@ -1,4 +1,4 @@
-import { Pressable, StyleSheet, Text } from 'react-native';
+import { Pressable, StyleSheet, Text, Alert } from 'react-native';
 import { useNavigation } from '@react-navigation/native';
 
 export const SingleActionButton = ({ payload }) => {

--- a/native/components/Button/SingleActionButton.jsx
+++ b/native/components/Button/SingleActionButton.jsx
@@ -26,7 +26,8 @@ export const SingleActionButton = ({ payload }) => {
   };
 
   const triggerAlert = () => {
-    
+    const { title, message, options } = payload;
+    Alert.alert(title, message, options);
   }
 
   switch (type) {
@@ -50,6 +51,13 @@ export const SingleActionButton = ({ payload }) => {
           <Text style={styles.text}>{text}</Text>
         </Pressable>
       );
+
+    case 'trigger-alert':
+      return (
+        <Pressable style={[styles.button, styles.default]} onPress={triggerAlert}>
+          <Text style={styles.text}>{text}</Text>
+        </Pressable>
+      )
 
     default:
       return (

--- a/native/components/Form/Form.jsx
+++ b/native/components/Form/Form.jsx
@@ -1,6 +1,6 @@
-import { handleTextChange } from '../../services/utils/handlers';
+import { handleTextChange, handleToggle } from '../../services/utils/handlers';
 import { SingleActionButton } from '../Button/SingleActionButton';
-import { Text, TextInput, View } from 'react-native';
+import { Text, TextInput, View, Switch } from 'react-native';
 import { Picker } from '@react-native-picker/picker';
 
 export const Form = ({ formData, formState }) => {
@@ -30,12 +30,18 @@ export const Form = ({ formData, formState }) => {
               ))}
             </Picker>
           ) : (
+            input.type === 'switch' ? (
+            <Switch 
+              value={stateObject[input.name]}
+              onValueChange={(e) => handleTextChange(e, input.name, setterFunction)}
+              />
+            ) : (
             <TextInput
               placeholder={input.name}
               value={stateObject[input.name]}
               onChangeText={(e) => handleTextChange(e, input.name, setterFunction)}
-            />
-          )}
+          />
+          ))}
         </View>
       ))}
       <SingleActionButton text={button.text} payload={submitForm} />

--- a/native/components/PortfolioCard/AddPortfolioProject.jsx
+++ b/native/components/PortfolioCard/AddPortfolioProject.jsx
@@ -7,15 +7,19 @@ import { View } from 'react-native';
 import { uiActions } from '../../services/redux/slices/uiSlice';
 import { portfolioProjectForm } from '../../services/formData';
 import { addPortfolioProject } from '../../services/api/users.js';
+import { SingleActionButton } from '../Button/SingleActionButton';
 
 export const AddPortfolioProject = () => {
   const { _id: userId } = useSelector((state) => state.ui.user);
   const dispatch = useDispatch();
   const [newProject, setNewProject] = useState({
     image: 'https://pbs.twimg.com/media/E5KGFT9X0AQzzaR?format=jpg&name=240x240',
-    project_description: '',
-    project_link: '',
     project_title: '',
+    role: '',
+    tools: '',
+    project_description: '',
+    // project_link: '',
+    // project_title: '',
     project_id: uuid.v4(),
   });
   // ideally updates the database on each new project without slowing the app down
@@ -37,9 +41,11 @@ export const AddPortfolioProject = () => {
   };
 
   const header = {
-    title: 'Portfolio Projects',
-    text: ' Add your personal projects here. You can add as many as you want, but to avoid cluttering we recommend a maximum of 3.',
+    title: 'Add Projects to Profile',
+    text: null,
   };
+
+
 
   return (
     // className="add-portfolio-project"

--- a/native/components/SideMenu.jsx
+++ b/native/components/SideMenu.jsx
@@ -15,6 +15,7 @@ import { SignUp } from '../screens/SignUp';
 import { SingleProject } from '../screens/SingleProject';
 import { UserDashboard } from '../screens/UserDashboard';
 import { UserProfile } from '../screens/UserProfile';
+import { CreateProfile } from '../screens/CreateProfile';
 // assets
 import { fetchAllProjects } from '../services/redux/actions/projectActions.js';
 import { fetchAllTools } from '../services/redux/actions/toolActions.js';
@@ -65,6 +66,7 @@ export const SideMenu = () => {
         <Drawer.Screen name="SignUp" component={SignUp} />
         <Drawer.Screen name="UserDashboard" component={UserDashboard} />
         <Drawer.Screen name="UserProfile" component={UserProfile} />
+        <Drawer.Screen name="CreateProfile" component={CreateProfile} />
       </Drawer.Navigator>
     </NavigationContainer>
   );

--- a/native/components/SideMenu.jsx
+++ b/native/components/SideMenu.jsx
@@ -21,6 +21,7 @@ import { fetchAllProjects } from '../services/redux/actions/projectActions.js';
 import { fetchAllTools } from '../services/redux/actions/toolActions.js';
 import { signOut, verify } from '../services/api/users';
 import { uiActions } from '../services/redux/slices/uiSlice';
+import { AddPortfolioProjects } from '../screens/AddPortfolioProjects';
 
 const Drawer = createDrawerNavigator();
 
@@ -67,6 +68,7 @@ export const SideMenu = () => {
         <Drawer.Screen name="UserDashboard" component={UserDashboard} />
         <Drawer.Screen name="UserProfile" component={UserProfile} />
         <Drawer.Screen name="CreateProfile" component={CreateProfile} />
+        <Drawer.Screen name="AddPortfolioProjects" component={AddPortfolioProjects} />
       </Drawer.Navigator>
     </NavigationContainer>
   );

--- a/native/screens/AddPortfolioProjects.jsx
+++ b/native/screens/AddPortfolioProjects.jsx
@@ -27,14 +27,16 @@ export const AddPortfolioProjects = ({navigation}) => {
         project_id: uuid.v4(),
     });
 
-    const empty = 
-        newProject.project_title === '' &&
-        newProject.role === '' &&
-        newProject.tools === '' &&
+    const emptyFields = 
+        newProject.project_title === '' ||
+        newProject.role === '' ||
+        newProject.tools === '' ||
         newProject.project_description === ''
 
     const handleNewProject = async () => {
-        try {
+        if ( emptyFields ) {
+            Alert.alert("Please fill in all fields.")
+        } else try {
             const res = await addPortfolioProject(userId, newProject);
             dispatch(uiActions.updateUser(res));
 
@@ -63,7 +65,13 @@ export const AddPortfolioProjects = ({navigation}) => {
         }
     };
 
-    const finish = !empty ? {
+    const unsavedProject = 
+        newProject.project_title !== '' ||
+        newProject.role !== '' ||
+        newProject.tools !== '' ||
+        newProject.project_description !== ''
+
+    const finish = unsavedProject ? {
         text: 'Finish',
         type: 'trigger-alert',
         message: "Finish without saving project?",

--- a/native/screens/AddPortfolioProjects.jsx
+++ b/native/screens/AddPortfolioProjects.jsx
@@ -1,11 +1,16 @@
-import { ScrollView, Alert } from 'react-native';
+// packages, libraries
 import uuid from 'react-native-uuid';
+import { ScrollView, Alert } from 'react-native';
 import { useSelector, useDispatch } from 'react-redux';
+import { useState } from 'react';
+
+//components
 import { Header } from '../components/Header/Header';
 import { portfolioProjectForm } from '../services/formData';
-import { useState } from 'react';
 import { Form } from '../components/Form/Form';
 import { SingleActionButton } from '../components/Button/SingleActionButton';
+
+//assets
 import { addPortfolioProject } from '../services/api/users';
 import { uiActions } from '../services/redux/slices/uiSlice';
 

--- a/native/screens/AddPortfolioProjects.jsx
+++ b/native/screens/AddPortfolioProjects.jsx
@@ -1,0 +1,92 @@
+import { ScrollView, Alert } from 'react-native';
+import uuid from 'react-native-uuid';
+import { useSelector, useDispatch } from 'react-redux';
+import { Header } from '../components/Header/Header';
+import { portfolioProjectForm } from '../services/formData';
+import { useState } from 'react';
+import { Form } from '../components/Form/Form';
+import { SingleActionButton } from '../components/Button/SingleActionButton';
+import { addPortfolioProject } from '../services/api/users';
+import { uiActions } from '../services/redux/slices/uiSlice';
+
+
+export const AddPortfolioProjects = ({navigation}) => {
+    const { _id: userId } = useSelector((state) => state.ui.user );
+    const dispatch = useDispatch();
+    const [ newProject, setNewProject ] = useState({
+        image: 'https://pbs.twimg.com/media/E5KGFT9X0AQzzaR?format=jpg&name=240x240',
+        project_title: '',
+        role: '',
+        tools: '',
+        project_description: '',
+        project_id: uuid.v4(),
+    });
+
+    const empty = 
+        newProject.project_title === '' &&
+        newProject.role === '' &&
+        newProject.tools === '' &&
+        newProject.project_description === ''
+
+    const handleNewProject = async () => {
+        try {
+            const res = await addPortfolioProject(userId, newProject);
+            dispatch(uiActions.updateUser(res));
+
+            Alert.alert(
+                "Project saved to portfolio.", 
+                null, 
+                [{
+                    text: 'Add another project',
+                },
+                {
+                    text: 'Finish sign up',
+                    onPress: () => navigation.navigate('UserDashboard'),
+                },
+            ]);
+
+            setNewProject({
+                image: 'https://pbs.twimg.com/media/E5KGFT9X0AQzzaR?format=jpg&name=240x240',
+                project_description: '',
+                project_link: '',
+                project_title: '',
+                project_id: uuid.v4(),
+            });
+
+        } catch (error) {
+            console.error(error);
+        }
+    };
+
+    const finish = !empty ? {
+        text: 'Finish',
+        type: 'trigger-alert',
+        message: "Finish without saving project?",
+        options: [
+            {
+                text: 'Save and Finish',
+                onPress: () => {},
+            },
+            {
+                text: 'Finish without saving',
+                onPress: () => navigation.navigate('Roulette'),
+            },
+            {
+                text: 'Cancel'
+            }
+        ]
+    } : {
+        text: 'Finish',
+        type: 'reroute',
+        path: 'Roulette',
+    }
+
+
+    return (
+        <ScrollView>
+            <Header headerTitle="Add Projects to Profile" />
+            <Form formData={portfolioProjectForm} formState={[newProject, setNewProject, handleNewProject]} />
+            <SingleActionButton payload={finish}/>
+        </ScrollView>
+    )
+};

--- a/native/screens/CreateProfile.jsx
+++ b/native/screens/CreateProfile.jsx
@@ -1,0 +1,69 @@
+// import React from 'react'
+import { useState, useEffect } from 'react';
+import { Text, ScrollView, View } from 'react-native';
+import { Header } from '../components/Header/Header';
+import { useSelector, useDispatch } from 'react-redux';
+import { uiActions } from '../services/redux/slices/uiSlice';
+import { updateUser } from '../services/api/users';
+import { userForm } from '../services/formData';
+import { Form } from '../components/Form/Form';
+import { AddPortfolioProject } from '../components/PortfolioCard/AddPortfolioProject';
+import { ShowPortfolioProjects } from '../components/PortfolioCard/ShowPortfolioProjects';
+
+export const CreateProfile = () => {
+    const { user: reduxUser, editMode } = useSelector((state) => state.ui);
+    const dispatch = useDispatch();
+
+    const header = {
+        title: "About Me",
+        text: null,
+    }
+
+    return (
+        <ScrollView>
+            <Header headerTitle={header.title} headerText={header.text} />
+            <AboutUser />
+        </ScrollView>
+    )
+};
+
+
+const AboutUser = () => {
+    const { editMode, user } = useSelector((state) => state.ui);
+    const dispatch = useDispatch();
+    const [userInfo, setUserInfo] = useState({
+        role: '',
+        about: '',
+        portfolio_link: '',
+        show_portfolio: false,
+        });
+    
+        useEffect(() => {
+        if (editMode) {
+            const { about, fun_fact, portfolio_link, role } = user;
+            setUserInfo({
+            about,
+            fun_fact,
+            portfolio_link,
+            role,
+            });
+        }
+        }, [editMode]);
+    
+        const handleUserUpdate = async () => {
+        try {
+            const res = await updateUser(user._id, userInfo);
+            dispatch(uiActions.updateUser(res));
+        } catch (error) {
+            console.error(error);
+        }
+        };
+    
+        return (
+        // className="about-user"
+        <View>
+            <Form formData={userForm} formState={[userInfo, setUserInfo, handleUserUpdate]} />
+        </View>
+        );
+    };
+    

--- a/native/screens/CreateProfile.jsx
+++ b/native/screens/CreateProfile.jsx
@@ -9,26 +9,38 @@ import { userForm } from '../services/formData';
 import { Form } from '../components/Form/Form';
 import { AddPortfolioProject } from '../components/PortfolioCard/AddPortfolioProject';
 import { ShowPortfolioProjects } from '../components/PortfolioCard/ShowPortfolioProjects';
+import { SingleActionButton } from '../components/Button/SingleActionButton';
 
 export const CreateProfile = () => {
     const { user: reduxUser, editMode } = useSelector((state) => state.ui);
     const dispatch = useDispatch();
+    const [ isCreated, setIsCreated ] = useState(false);
 
-    const header = {
-        title: "About Me",
-        text: null,
+
+    const finish = {
+        text: '',
+        type: '',
+        options: [],
     }
 
     return (
         <ScrollView>
-            <Header headerTitle={header.title} headerText={header.text} />
-            <AboutUser />
+            { !isCreated ? 
+                <AboutUser setIsCreated={setIsCreated} /> 
+                :
+                (
+                <>
+                    <AddPortfolioProject />
+                    <SingleActionButton payload={finish} />
+                </>)
+            }
+            
         </ScrollView>
     )
 };
 
 
-const AboutUser = () => {
+const AboutUser = ({setIsCreated}) => {
     const { editMode, user } = useSelector((state) => state.ui);
     const dispatch = useDispatch();
     const [userInfo, setUserInfo] = useState({
@@ -54,14 +66,21 @@ const AboutUser = () => {
         try {
             const res = await updateUser(user._id, userInfo);
             dispatch(uiActions.updateUser(res));
+            setIsCreated(true);
         } catch (error) {
             console.error(error);
         }
         };
+
+        const header = {
+            title: "Create Profile",
+            text: null,
+        }
     
         return (
         // className="about-user"
         <View>
+            <Header headerTitle={header.title} headerText={header.text} />
             <Form formData={userForm} formState={[userInfo, setUserInfo, handleUserUpdate]} />
         </View>
         );

--- a/native/screens/CreateProfile.jsx
+++ b/native/screens/CreateProfile.jsx
@@ -1,6 +1,6 @@
 // import React from 'react'
 import { useState} from 'react';
-import { ScrollView } from 'react-native';
+import { ScrollView, Button } from 'react-native';
 import { Header } from '../components/Header/Header';
 import { useSelector, useDispatch } from 'react-redux';
 import { uiActions } from '../services/redux/slices/uiSlice';
@@ -32,6 +32,7 @@ export const CreateProfile = ({navigation}) => {
         <ScrollView>
             <Header headerTitle="Create Profile" headerText="" />
             <Form formData={createProfile} formState={[userInfo, setUserInfo, handleUserUpdate]} />
+            <Button title="Complete later" onPress={() => navigation.navigate('Roulette')} />
         </ScrollView>
     )
 };

--- a/native/screens/CreateProfile.jsx
+++ b/native/screens/CreateProfile.jsx
@@ -1,51 +1,15 @@
 // import React from 'react'
-import { useState, useEffect } from 'react';
-import { Text, ScrollView, View } from 'react-native';
+import { useState} from 'react';
+import { ScrollView } from 'react-native';
 import { Header } from '../components/Header/Header';
 import { useSelector, useDispatch } from 'react-redux';
 import { uiActions } from '../services/redux/slices/uiSlice';
 import { updateUser } from '../services/api/users';
-import { userForm } from '../services/formData';
 import { Form } from '../components/Form/Form';
-import { AddPortfolioProject } from '../components/PortfolioCard/AddPortfolioProject';
-import { ShowPortfolioProjects } from '../components/PortfolioCard/ShowPortfolioProjects';
-import { SingleActionButton } from '../components/Button/SingleActionButton';
+import { createProfile } from '../services/formData';
 
-export const CreateProfile = () => {
-    const { user: reduxUser, editMode } = useSelector((state) => state.ui);
-    const dispatch = useDispatch();
-    const [ isCreated, setIsCreated ] = useState(false);
-
-
-    const finish = {
-        text: 'Finish',
-        type: 'trigger-alert',
-        options: [
-            {
-                
-            }
-        ],
-    }
-
-    return (
-        <ScrollView>
-            { !isCreated ? 
-                <AboutUser setIsCreated={setIsCreated} /> 
-                :
-                (
-                <>
-                    <AddPortfolioProject />
-                    <SingleActionButton payload={finish} />
-                </>)
-            }
-            
-        </ScrollView>
-    )
-};
-
-
-const AboutUser = ({setIsCreated}) => {
-    const { editMode, user } = useSelector((state) => state.ui);
+export const CreateProfile = ({navigation}) => {
+    const { user } = useSelector((state) => state.ui);
     const dispatch = useDispatch();
     const [userInfo, setUserInfo] = useState({
         role: '',
@@ -54,39 +18,20 @@ const AboutUser = ({setIsCreated}) => {
         show_portfolio: false,
         });
     
-        useEffect(() => {
-        if (editMode) {
-            const { about, fun_fact, portfolio_link, role } = user;
-            setUserInfo({
-            about,
-            fun_fact,
-            portfolio_link,
-            role,
-            });
-        }
-        }, [editMode]);
-    
-        const handleUserUpdate = async () => {
+    const handleUserUpdate = async () => {
         try {
             const res = await updateUser(user._id, userInfo);
             dispatch(uiActions.updateUser(res));
-            setIsCreated(true);
+            navigation.navigate('AddPortfolioProjects')
         } catch (error) {
             console.error(error);
         }
-        };
-
-        const header = {
-            title: "Create Profile",
-            text: null,
-        }
-    
-        return (
-        // className="about-user"
-        <View>
-            <Header headerTitle={header.title} headerText={header.text} />
-            <Form formData={userForm} formState={[userInfo, setUserInfo, handleUserUpdate]} />
-        </View>
-        );
     };
-    
+
+    return (
+        <ScrollView>
+            <Header headerTitle="Create Profile" headerText="" />
+            <Form formData={createProfile} formState={[userInfo, setUserInfo, handleUserUpdate]} />
+        </ScrollView>
+    )
+};

--- a/native/screens/CreateProfile.jsx
+++ b/native/screens/CreateProfile.jsx
@@ -1,11 +1,15 @@
-// import React from 'react'
+// packages, libraries
 import { useState} from 'react';
 import { ScrollView, Button } from 'react-native';
-import { Header } from '../components/Header/Header';
 import { useSelector, useDispatch } from 'react-redux';
+
+// components
+import { Header } from '../components/Header/Header';
+import { Form } from '../components/Form/Form';
+
+// assets
 import { uiActions } from '../services/redux/slices/uiSlice';
 import { updateUser } from '../services/api/users';
-import { Form } from '../components/Form/Form';
 import { createProfile } from '../services/formData';
 
 export const CreateProfile = ({navigation}) => {

--- a/native/screens/CreateProfile.jsx
+++ b/native/screens/CreateProfile.jsx
@@ -18,9 +18,13 @@ export const CreateProfile = () => {
 
 
     const finish = {
-        text: '',
-        type: '',
-        options: [],
+        text: 'Finish',
+        type: 'trigger-alert',
+        options: [
+            {
+                
+            }
+        ],
     }
 
     return (

--- a/native/screens/SignUp.jsx
+++ b/native/screens/SignUp.jsx
@@ -98,10 +98,10 @@ export const SignUp = ({ navigation }) => {
           {/* Replace these with SingleButton or DoubleButton component*/}
           <TouchableOpacity
             style={styles.singleButton}
-            onPress={() => handleReroute('EditProfile')}
+            onPress={() => handleReroute('CreateProfile')}
             color="white"
           >
-            <Text style={styles.buttonText}>Edit Profile</Text>
+            <Text style={styles.buttonText}>Create Profile</Text>
           </TouchableOpacity>
           <TouchableOpacity
             style={styles.singleButton}

--- a/native/services/formData.js
+++ b/native/services/formData.js
@@ -61,7 +61,7 @@ export const signUpForm = {
 */
 export const userForm = {
   button: {
-    text: 'Update Your Info',
+    text: 'Next',
     type: 'single',
   },
   handlers: {
@@ -70,30 +70,36 @@ export const userForm = {
   },
   inputs: [
     {
-      labelText: 'Tell us a bit about you (max 250 characters)',
-      name: 'about',
-      max_chars: 250,
-      required: true,
-      type: 'textarea',
-    },
-    {
-      labelText: 'Include a fun fact!   (optional, max 250 characters) ',
-      name: 'fun_fact',
-      max_chars: 250,
-      type: 'textarea',
-    },
-    {
-      labelText: 'I am a...',
+      labelText: 'Occupation',
       name: 'role',
       required: true,
       type: 'select',
       options: ['Select role', 'UX Designer', 'Software Engineer'],
     },
     {
-      labelText: 'Link to your portfolio (optional)',
+      labelText: 'Bio',
+      name: 'about',
+      max_chars: 250,
+      required: true,
+      type: 'textarea',
+    },
+    // {
+    //   labelText: 'Include a fun fact!   (optional, max 250 characters) ',
+    //   name: 'fun_fact',
+    //   max_chars: 250,
+    //   type: 'textarea',
+    // },
+
+    {
+      labelText: 'Portfolio Link',
       name: 'portfolio_link',
       type: 'text',
     },
+    {
+      labelText: 'Share on Profile?',
+      name: 'show_portolio',
+      type: 'checkbox',
+    }
   ],
 };
 

--- a/native/services/formData.js
+++ b/native/services/formData.js
@@ -1,3 +1,5 @@
+
+
 /* 
   authentication forms
  */
@@ -105,7 +107,7 @@ export const userForm = {
 
 export const portfolioProjectForm = {
   button: {
-    text: 'Add New Project',
+    text: 'Save',
     type: 'single',
   },
   handlers: {
@@ -119,17 +121,29 @@ export const portfolioProjectForm = {
       type: 'text',
     },
     {
-      labelText: 'Describe the project',
+      labelText: 'Role',
+      name: 'role',
+      required: true,
+      type: 'text',
+    },
+    {
+      labelText: 'Tools Used',
+      name: 'tools',
+      required: true,
+      type: 'text',
+    },
+    {
+      labelText: 'About',
       name: 'project_description',
       required: true,
       type: 'textarea',
     },
-    {
-      labelText: 'Link to your project',
-      name: 'project_link',
-      required: true,
-      type: 'text',
-    },
+    // {
+    //   labelText: 'Link to your project',
+    //   name: 'project_link',
+    //   required: true,
+    //   type: 'text',
+    // },
   ],
 };
 

--- a/native/services/formData.js
+++ b/native/services/formData.js
@@ -61,6 +61,45 @@ export const signUpForm = {
 /* 
   user related forms 
 */
+
+export const createProfile = {
+  button: {
+      text: 'Next',
+      type: 'single',
+      },
+  handlers: {
+    // setterFunction: ,
+    // onSubmit: ,
+  },
+  inputs: [
+      {
+          labelText: 'I am a',
+          name: 'role',
+          required: true,
+          type: 'select',
+          options: ['Select Occupation', 'UX Designer', 'Software Engineer'],
+      },
+      {
+          labelText: 'About Me',
+          name: 'about',
+          max_chars: 250,
+          required: true,
+          type: 'textarea',
+      },
+      {
+          labelText: 'Portfolio Link',
+          name: 'portfolio_link',
+          type: 'text',
+      },
+      {
+          labelText: 'Share on Profile?',
+          name: 'show_portfolio',
+          type: 'switch',
+      }
+  ],
+};
+
+
 export const userForm = {
   button: {
     text: 'Next',


### PR DESCRIPTION
This pull request...
      - Breaks new user's create profile flow into two screens: Create Profile (user info) + Add Portfolio Projects to Profile
     - Adjusts form data for user info and portfolio projects to match Figma
     - Adds triggerAlert button type to SingleActionButton
     - Adds react native Switch type (toggle) to Form component
     - Adds show_portfolio property to user model on backend

Comments: 
     - Will have to circle back to best approach for the tools input. Didn't want to invest too much into this before understanding UX teams final vision for this input
