### PR TITLE
Screen/native account settings

### DIFF
--- a/backend/controllers/users.js
+++ b/backend/controllers/users.js
@@ -1,9 +1,7 @@
 import User from "../models/user.js";
 import jwt from "jsonwebtoken";
 import bcrypt from "bcrypt";
-import project from "../models/project.js";
-// project id gamebot: 61e090dc02b0f84cd989cd1b
-// user id wiggle: 61e090dc02b0f84cd989cd13
+
 const SALT_ROUNDS = Number(process.env.SALT_ROUNDS) || 11;
 
 const TOKEN_KEY =
@@ -17,7 +15,7 @@ exp.setDate(today.getDate() + 30);
 
 export const getAllUsers = async (req, res) => {
   try {
-    const users = await User.find()  //.populate({
+    const users = await User.find(); //.populate({
     //   path: "member_of_projects",
     //   model: project,
     // });
@@ -26,51 +24,56 @@ export const getAllUsers = async (req, res) => {
     console.log(error.message);
     res.status(500).json({ error: error.message });
   }
-}; 
+};
 
 export const getOneUser = async (req, res) => {
   try {
-    const {id} = req.params;
+    const { id } = req.params;
     const user = await User.findById(id);
     if (user) {
-      return res.json(user)
+      return res.json(user);
     }
-    return res.status(404).json({message: 'User not found.'})
+    return res.status(404).json({ message: "User not found." });
   } catch (error) {
-    console.error(error).message
+    console.error(error.message);
     res.status(500).json({ error: error.message });
   }
-}
+};
 
 export const deleteUser = async (req, res) => {
   try {
     const { id } = req.params;
     const deletedUser = await User.findByIdAndDelete(id);
     if (deletedUser) {
-      console.log("deletedUser:", deletedUser)
-      return res.status(200).send({deletionStatus: true, message: "Project deleted."});
+      return res
+        .status(200)
+        .send({ deletionStatus: true, message: "User deleted." });
     }
-    throw new Error("Project not found.");
+    throw new Error("User not found.");
   } catch (error) {
     console.log(error.message);
-    res.status(500).json({ deletionState: false, error: error.message });
+    res.status(500).json({ deletionStatus: false, error: error.message });
   }
-}; 
+};
 
 export const addPortfolioProject = async (req, res) => {
   try {
     const { id } = req.params;
-    const user = await User.findByIdAndUpdate(id, {$push: {'portfolio_projects': req.body }}, {new:true});
-    // i believe this can be handled better by throwing an error rather than responding with a 404 
+    const user = await User.findByIdAndUpdate(
+      id,
+      { $push: { portfolio_projects: req.body } },
+      { new: true }
+    );
+    // i believe this can be handled better by throwing an error rather than responding with a 404
     if (user) {
       return res.status(200).send(user);
     } else {
-      return res.status(404).json({message: 'User not found.'})
+      return res.status(404).json({ message: "User not found." });
     }
-  } catch(error) {
+  } catch (error) {
     res.status(500).send(error.message);
   }
-}
+};
 
 export const updateUserInfo = async (req, res) => {
   try {
@@ -84,16 +87,18 @@ export const updateUserInfo = async (req, res) => {
 
 export const checkEmail = async (req, res) => {
   try {
-    const user = await User.findOne({ email: req.body.email});
+    const user = await User.findOne({ email: req.body.email });
     if (user) {
-      return res.json({message: "An account with this email address already exists."})
+      return res.json({
+        message: "An account with this email address already exists.",
+      });
     }
-    return res.status(200).json({message: false})
+    return res.status(200).json({ message: false });
   } catch (error) {
-    console.error({ err: error.message })
+    console.error({ err: error.message });
     res.status(500).json({ error: error.message });
   }
-}
+};
 
 // Auth
 export const signUp = async (req, res) => {
@@ -105,14 +110,16 @@ export const signUp = async (req, res) => {
     await user.save();
 
     const payload = {
-      id: user._id,
+      userID: user._id,
       email: user.email,
       exp: parseInt(exp.getTime() / 1000),
     };
     const token = jwt.sign(payload, TOKEN_KEY);
-    let secureUser = Object.assign({}, user._doc, {"password_digest": undefined})
+    let secureUser = Object.assign({}, user._doc, {
+      password_digest: undefined,
+    });
 
-    res.status(201).json({user: secureUser, token });
+    res.status(201).json({ user: secureUser, token });
   } catch (error) {
     console.error(error.message);
     res.status(400).json({ error: error.message });
@@ -125,10 +132,12 @@ export const signIn = async (req, res) => {
     let user = await User.findOne({ email }).select(
       "about email first_name fun_fact interested_projects last_name member_of_projects password_digest portfolio_projects portfolio_link rejected_projects role"
     ); // to avoid setting `select` to true on the user model, i select all properties here then copy the user object without the password_digest below
-    let secureUser = Object.assign({}, user._doc, {"password_digest": undefined})
+    let secureUser = Object.assign({}, user._doc, {
+      password_digest: undefined,
+    });
     if (await bcrypt.compare(password, user.password_digest)) {
       const payload = {
-        id: user._id,
+        userID: user._id,
         email: user.email,
         exp: parseInt(exp.getTime() / 1000),
       };
@@ -141,7 +150,7 @@ export const signIn = async (req, res) => {
     console.log(error.message);
     res.status(500).json({ error: error.message });
   }
-}; 
+};
 
 export const verify = async (req, res) => {
   try {
@@ -157,32 +166,40 @@ export const verify = async (req, res) => {
 };
 
 export const confirmPassword = async (req, res) => {
-  const { credentials} = req.body;
-  const {email, password} = credentials;
-  // is it better to find the user by their email or id? 
-  let user = await User.findOne({ email }).select(
-    "password_digest"
-  );
-  if (await bcrypt.compare(password, user.password_digest)) {
-    res.status(201).json({passwordConfirmed: true});
+  const { email, password } = req.body;
+  // is it better to find the user by their email or id?
+  console.log("email", email);
+  if (email) {
+    let user = await User.findOne({ email }).select("password_digest");
+    if (await bcrypt.compare(password, user.password_digest)) {
+      res.status(201).json({ passwordConfirmed: true });
+    } else {
+      res.status(401).json({ passwordConfirmed: false }); // status code: unnacceptable lol
+    }
   } else {
-    res.status(406).json({passwordConfirmed: false}); // status code: unnacceptable lol
+    res.status(401).json({ passwordConfirmed: false });
   }
-}
+};
 
 export const updatePassword = async (req, res) => {
   try {
-    const {newPassword} = req.body
-    const {userID} = req.params
+    const { newPassword } = req.body;
+    const { userID } = req.params;
     const newPasswordDigest = await bcrypt.hash(newPassword, SALT_ROUNDS);
-    const user = await User.findByIdAndUpdate(userID, {password_digest: newPasswordDigest }, { new: true });
+    const user = await User.findByIdAndUpdate(
+      userID,
+      { password_digest: newPasswordDigest },
+      { new: true }
+    );
     const payload = {
-        userID: user._id,
-        email: user.email,
-        exp: parseInt(exp.getTime() / 1000),
-      };
+      userID: user._id,
+      email: user.email,
+      exp: parseInt(exp.getTime() / 1000),
+    };
     const token = jwt.sign(payload, TOKEN_KEY);
-    res.status(201).json({status: true, message: "Password Updated", user, token});
+    res
+      .status(201)
+      .json({ status: true, message: "Password Updated", user, token });
   } catch (error) {
     console.error(error.message);
     res.status(400).json({ status: false, message: error.message });

--- a/backend/controllers/users.js
+++ b/backend/controllers/users.js
@@ -26,7 +26,7 @@ export const getAllUsers = async (req, res) => {
     console.log(error.message);
     res.status(500).json({ error: error.message });
   }
-}; //works
+}; 
 
 export const getOneUser = async (req, res) => {
   try {
@@ -55,7 +55,7 @@ export const deleteUser = async (req, res) => {
     console.log(error.message);
     res.status(500).json({ deletionState: false, error: error.message });
   }
-}; // works
+}; 
 
 export const addPortfolioProject = async (req, res) => {
   try {
@@ -80,7 +80,7 @@ export const updateUserInfo = async (req, res) => {
   } catch (error) {
     res.status(500).send(error.message);
   }
-}; // works
+};
 
 export const checkEmail = async (req, res) => {
   try {
@@ -117,7 +117,7 @@ export const signUp = async (req, res) => {
     console.error(error.message);
     res.status(400).json({ error: error.message });
   }
-}; // works
+};
 
 export const signIn = async (req, res) => {
   try {
@@ -141,7 +141,7 @@ export const signIn = async (req, res) => {
     console.log(error.message);
     res.status(500).json({ error: error.message });
   }
-}; // works
+}; 
 
 export const verify = async (req, res) => {
   try {
@@ -157,20 +157,30 @@ export const verify = async (req, res) => {
 };
 
 export const confirmPassword = async (req, res) => {
-  const { credentials} = req;
-  const { email, password } = credentials;
+  const { email, password} = req.body;
   let user = await User.findOne({ email }).select(
-    "about email first_name fun_fact interested_projects last_name member_of_projects password_digest portfolio_projects portfolio_link rejected_projects role"
-  ); // to avoid setting `select` to true on the user model, i select all properties here then copy the user object without the password_digest below
+    "password_digest"
+  );
   if (await bcrypt.compare(password, user.password_digest)) {
-    const payload = {
-      id: user._id,
-      email: user.email,
-      exp: parseInt(exp.getTime() / 1000),
-    };
-    const token = jwt.sign(payload, TOKEN_KEY);
-    res.status(201).json({ token });
+    res.status(201).send(true);
   } else {
-    res.status(401).json({ error: error.message });
+    res.status(401).send(false);
   }
 }
+
+export const updatePassword = async (req, res) => {
+  try {
+    const newPasswordDigest = await bcrypt.hash(req.newPassword, SALT_ROUNDS);
+    const user = await User.findByIdAndUpdate(id, {password_digest: newPasswordDigest }, { new: true });
+    const payload = {
+        id: user._id,
+        email: user.email,
+        exp: parseInt(exp.getTime() / 1000),
+      };
+    const token = jwt.sign(payload, TOKEN_KEY);
+    res.status(201).json({status: true, message: "Password Updated", user, token});
+  } catch (error) {
+    console.error(error.message);
+    res.status(400).json({ status: false, message: error.message });
+  }
+};

--- a/backend/controllers/users.js
+++ b/backend/controllers/users.js
@@ -157,7 +157,9 @@ export const verify = async (req, res) => {
 };
 
 export const confirmPassword = async (req, res) => {
-  const { email, password} = req.body;
+  const { credentials} = req.body;
+  const {email, password} = credentials;
+  // is it better to find the user by their email or id? 
   let user = await User.findOne({ email }).select(
     "password_digest"
   );

--- a/backend/controllers/users.js
+++ b/backend/controllers/users.js
@@ -162,18 +162,20 @@ export const confirmPassword = async (req, res) => {
     "password_digest"
   );
   if (await bcrypt.compare(password, user.password_digest)) {
-    res.status(201).send(true);
+    res.status(201).json({passwordConfirmed: true});
   } else {
-    res.status(401).send(false);
+    res.status(406).json({passwordConfirmed: false}); // status code: unnacceptable lol
   }
 }
 
 export const updatePassword = async (req, res) => {
   try {
-    const newPasswordDigest = await bcrypt.hash(req.newPassword, SALT_ROUNDS);
-    const user = await User.findByIdAndUpdate(id, {password_digest: newPasswordDigest }, { new: true });
+    const {newPassword} = req.body
+    const {userID} = req.params
+    const newPasswordDigest = await bcrypt.hash(newPassword, SALT_ROUNDS);
+    const user = await User.findByIdAndUpdate(userID, {password_digest: newPasswordDigest }, { new: true });
     const payload = {
-        id: user._id,
+        userID: user._id,
         email: user.email,
         exp: parseInt(exp.getTime() / 1000),
       };

--- a/backend/prettier.config.js
+++ b/backend/prettier.config.js
@@ -1,7 +1,0 @@
-module.exports = {
-  printWidth: 100,
-  tabWidth: 2,
-  useTabs: false,
-  singleQuote: true,
-  trailingComma: 'es5',
-};

--- a/backend/prettier.config.json
+++ b/backend/prettier.config.json
@@ -1,0 +1,7 @@
+{
+  "printWidth": 100,
+  "tabWidth": 2,
+  "useTabs": false,
+  "singleQuote": true,
+  "trailingComma": "es5"
+}

--- a/backend/routes/users.js
+++ b/backend/routes/users.js
@@ -16,5 +16,8 @@ router.delete('/users/:id', controllers.deleteUser);
 router.post("/sign-in", controllers.signIn);
 router.get("/verify", controllers.verify);
 router.post("/email", controllers.checkEmail)
+router.post('/confirm-password/:userID', controllers.confirmPassword);
+router.patch('/update-password/:userID', controllers.updatePassword);
+
 
 export default router;

--- a/backend/routes/users.js
+++ b/backend/routes/users.js
@@ -10,6 +10,7 @@ router.get('/users/:id', controllers.getOneUser);
 router.post("/sign-up", controllers.signUp);
 router.put("/users/:id", controllers.updateUserInfo);
 router.patch('/users/:id', controllers.addPortfolioProject);
+router.delete('/users/:id', controllers.deleteUser);
 
 // auth
 router.post("/sign-in", controllers.signIn);

--- a/native/App.js
+++ b/native/App.js
@@ -1,88 +1,12 @@
 import 'react-native-gesture-handler';
-// packages
-// import { useEffect } from 'react';
 import { Provider } from 'react-redux';
 import store from './services/redux/store.js';
-// native components
-// import { NavigationContainer } from '@react-navigation/native';
-import { createNativeStackNavigator } from '@react-navigation/native-stack';
 import { SideMenu } from './components/SideMenu';
-// custom components
-// import { Landing } from './screens/Landing';
-// import { CreateProject } from './screens/CreateProject';
-// import { EditProject } from './screens/EditProject';
-// import { SingleProject } from './screens/SingleProject';
-// import { Roulette } from './screens/Roulette';
-// import { SignIn } from './screens/SignIn';
-// import { SignUp } from './screens/SignUp';
-// import { UserDashboard } from './screens/UserDashboard';
-// import { UserProfile } from './screens/UserProfile';
-// import { EditProfile } from './screens/EditProfile/EditProfile';
-// assets
-
-const Stack = createNativeStackNavigator();
 
 export default function App() {
   return (
     <Provider store={store}>
       <SideMenu />
-      {/* <Stack.Navigator>
-        <Stack.Screen
-        name="Landing"
-        component={Landing}
-        options={{ title: "welcome" }}
-        />
-        <Stack.Screen
-          name="CreateProject"
-          component={CreateProject}
-          options={{ title: "welcome" }}
-        />
-        <Stack.Screen
-          name="EditProject"
-          component={EditProject}
-          options={{ title: "welcome" }}
-        />
-        <Stack.Screen
-        name="SingleProject"
-          component={SingleProject}
-          options={{ title: "welcome" }}
-        />
-        <Stack.Screen
-        name="Roulette"
-        component={Roulette}
-          options={{ title: "welcome" }}
-        />
-        <Stack.Screen
-          name="SignIn"
-          component={SignIn}
-          options={{ title: "welcome" }}
-          />
-        <Stack.Screen
-          name="SignUp"
-          component={SignUp}
-          options={{ title: "welcome" }}
-        />
-        <Stack.Screen
-          name="UserDashboard"
-          component={UserDashboard}
-          options={{ title: "welcome" }}
-        />
-        <Stack.Screen
-          name="UserProfile"
-          component={UserProfile}
-          options={{ title: "welcome" }}
-        />
-        <Stack.Screen
-          name="EditProfile"
-          component={EditProfile}
-          options={{ title: "welcome" }}
-        />
-      </Stack.Navigator> */}
     </Provider>
-
-    // <View style={styles.container}>
-    //   <Text>Open up App.js to start working on your app!</Text>
-    //   <StatusBar style="auto" />
-    // </View>
   );
 }

--- a/native/components/SideMenu.jsx
+++ b/native/components/SideMenu.jsx
@@ -4,7 +4,7 @@ import { NavigationContainer } from '@react-navigation/native';
 import { useEffect, useState } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 // screens
-import { AccountSettings } from '../screens/AccountSettings';
+import { AccountSettings } from '../screens/AccountSettings/AccountSettings';
 import { Applicants } from '../screens/Applicants/Applicants';
 import { CreateProject } from '../screens/CreateProject';
 import { EditProfile } from '../screens/EditProfile';

--- a/native/components/SideMenu.jsx
+++ b/native/components/SideMenu.jsx
@@ -20,26 +20,30 @@ import { UserProfile } from '../screens/UserProfile';
 // assets
 import { fetchAllProjects } from '../services/redux/actions/projectActions.js';
 import { fetchAllTools } from '../services/redux/actions/toolActions.js';
-import { signOut, verify } from '../services/api/users';
+import { verify } from '../services/api/users';
 import { uiActions } from '../services/redux/slices/uiSlice';
+import * as SecureStore from 'expo-secure-store';
 
 const Drawer = createDrawerNavigator();
 
 export const SideMenu = () => {
   const dispatch = useDispatch();
-  const { blacklisted_projects, user } = useSelector((state) => state.ui);
+  const { blacklisted_projects } = useSelector((state) => state.ui);
   const [userLoaded, toggleUserLoaded] = useState(false);
 
   useEffect(() => {
     const setupReduxStore = async () => {
-      const verifiedUser = await verify();
-      if (verifiedUser) {
-        dispatch(uiActions.updateUser(verifiedUser));
-      } else {
-        dispatch(uiActions.updateUser(null));
+      const userTokenExists = await SecureStore.getItemAsync('token');
+      if (userTokenExists) {
+        const verifiedUser = await verify();
+        if (verifiedUser) {
+          dispatch(uiActions.updateUser(verifiedUser));
+        } else {
+          dispatch(uiActions.updateUser(null));
+        }
+        dispatch(fetchAllTools());
+        toggleUserLoaded(true);
       }
-      dispatch(fetchAllTools());
-      toggleUserLoaded(true);
     };
     setupReduxStore();
   }, []);

--- a/native/components/SideMenu.jsx
+++ b/native/components/SideMenu.jsx
@@ -4,6 +4,7 @@ import { NavigationContainer } from '@react-navigation/native';
 import { useEffect, useState } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 // screens
+import { AccountSettings } from '../screens/AccountSettings';
 import { Applicants } from '../screens/Applicants/Applicants';
 import { CreateProject } from '../screens/CreateProject';
 import { EditProfile } from '../screens/EditProfile';
@@ -56,6 +57,7 @@ export const SideMenu = () => {
       <Drawer.Navigator>
         <Drawer.Screen name="Landing" component={Landing} />
         {/* Landing is at the top of the list therefore is loaded fist on application open & refresh*/}
+        <Drawer.Screen name="AccountSettings" component={AccountSettings} />
         <Drawer.Screen name="Applicants" component={Applicants} />
         <Drawer.Screen name="CreateProject" component={CreateProject} />
         <Drawer.Screen name="EditProfile" component={EditProfile} />

--- a/native/components/SideMenu.jsx
+++ b/native/components/SideMenu.jsx
@@ -10,6 +10,7 @@ import { EditProfile } from '../screens/EditProfile';
 import { EditProject } from '../screens/EditProject/EditProject';
 import { Landing } from '../screens/Landing';
 import { Roulette } from '../screens/Roulette';
+import { Settings } from '../screens/Settings';
 import { SignIn } from '../screens/SignIn';
 import { SignUp } from '../screens/SignUp';
 import { SingleProject } from '../screens/SingleProject';
@@ -60,6 +61,7 @@ export const SideMenu = () => {
         <Drawer.Screen name="EditProfile" component={EditProfile} />
         <Drawer.Screen name="EditProject" component={EditProject} />
         <Drawer.Screen name="Roulette" component={Roulette} />
+        <Drawer.Screen name="Settings" component={Settings} />
         <Drawer.Screen name="SingleProject" component={SingleProject} />
         <Drawer.Screen name="SignIn" component={SignIn} />
         <Drawer.Screen name="SignUp" component={SignUp} />

--- a/native/package-lock.json
+++ b/native/package-lock.json
@@ -3231,10 +3231,27 @@
       "resolved": "https://registry.npmjs.org/@react-native/polyfills/-/polyfills-1.0.0.tgz",
       "integrity": "sha512-0jbp4RxjYopTsIdLl+/Fy2TiwVYHy4mgeu07DG4b/LyM0OS/+lPP5c9sbnt/AMlnF6qz2JRZpPpGw1eMNS6A4w=="
     },
+    "node_modules/@react-navigation/bottom-tabs": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/@react-navigation/bottom-tabs/-/bottom-tabs-6.3.1.tgz",
+      "integrity": "sha512-sL9F4WMhhR6I9bE7bpsPVHnK1cN9doaFHAuy5YmD+Sw6OyO0TAmNgQFx4xZWqboA5ZwSkN0tWcRCr6wGXaRRag==",
+      "dependencies": {
+        "@react-navigation/elements": "^1.3.3",
+        "color": "^3.1.3",
+        "warn-once": "^0.1.0"
+      },
+      "peerDependencies": {
+        "@react-navigation/native": "^6.0.0",
+        "react": "*",
+        "react-native": "*",
+        "react-native-safe-area-context": ">= 3.0.0",
+        "react-native-screens": ">= 3.0.0"
+      }
+    },
     "node_modules/@react-navigation/core": {
-      "version": "6.1.1",
-      "resolved": "https://registry.npmjs.org/@react-navigation/core/-/core-6.1.1.tgz",
-      "integrity": "sha512-njysuiqztgvR1Z9Noxk2OGJfYtFGFDRyji5Vmm1jHzlql0m+q0wh1dUiyaIEtTyrhFXr/YNgdrKuiPaU9Jp8OA==",
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/@react-navigation/core/-/core-6.2.1.tgz",
+      "integrity": "sha512-3mjS6ujwGnPA/BC11DN9c2c42gFld6B6dQBgDedxP2djceXESpY2kVTTwISDHuqFnF7WjvRjsrDu3cKBX+JosA==",
       "dependencies": {
         "@react-navigation/routers": "^6.1.0",
         "escape-string-regexp": "^4.0.0",
@@ -3282,9 +3299,9 @@
       }
     },
     "node_modules/@react-navigation/elements": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/@react-navigation/elements/-/elements-1.3.1.tgz",
-      "integrity": "sha512-jIDRJaG8YPIinl4hZXJu/W3TnhDe8hLYmGSEdL1mxZ1aoNMiApCBYkgTy11oq0EfK/koZd3DPSkJNbzBAQmPJw==",
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/@react-navigation/elements/-/elements-1.3.3.tgz",
+      "integrity": "sha512-Lv2lR7si5gNME8dRsqz57d54m4FJtrwHRjNQLOyQO546ZxO+g864cSvoLC6hQedQU0+IJnPTsZiEI2hHqfpEpw==",
       "peerDependencies": {
         "@react-navigation/native": "^6.0.0",
         "react": "*",
@@ -3293,11 +3310,11 @@
       }
     },
     "node_modules/@react-navigation/native": {
-      "version": "6.0.8",
-      "resolved": "https://registry.npmjs.org/@react-navigation/native/-/native-6.0.8.tgz",
-      "integrity": "sha512-6022M3+Btok3xJC/49B88er3SRrlDAZ4FdmGndhEVvBcGSHWmscU2qKCwFd0RY6A0AGCVmdIlXudrfdcdRAkpQ==",
+      "version": "6.0.10",
+      "resolved": "https://registry.npmjs.org/@react-navigation/native/-/native-6.0.10.tgz",
+      "integrity": "sha512-H6QhLeiieGxNcAJismIDXIPZgf1myr7Og8v116tezIGmincJTOcWavTd7lPHGnMMXaZg94LlVtbaBRIx9cexqw==",
       "dependencies": {
-        "@react-navigation/core": "^6.1.1",
+        "@react-navigation/core": "^6.2.1",
         "escape-string-regexp": "^4.0.0",
         "fast-deep-equal": "^3.1.3",
         "nanoid": "^3.1.23"
@@ -3340,6 +3357,24 @@
       "integrity": "sha512-8xJL+djIzpFdRW/sGlKojQ06fWgFk1c5jER9501HYJ12LF5DIJFr/tqBI2TJ6bk+y+QFu0nbNyeRC80OjRlmkA==",
       "dependencies": {
         "nanoid": "^3.1.23"
+      }
+    },
+    "node_modules/@react-navigation/stack": {
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/@react-navigation/stack/-/stack-6.2.1.tgz",
+      "integrity": "sha512-JI7boxtPAMCBXi4VJHVEq61jLVHFW5f3npvbndS+XfOsv7Gf0f91HOVJ28DS5c2Fn4+CO4AByjUozzlN296X+A==",
+      "dependencies": {
+        "@react-navigation/elements": "^1.3.3",
+        "color": "^3.1.3",
+        "warn-once": "^0.1.0"
+      },
+      "peerDependencies": {
+        "@react-navigation/native": "^6.0.0",
+        "react": "*",
+        "react-native": "*",
+        "react-native-gesture-handler": ">= 1.0.0",
+        "react-native-safe-area-context": ">= 3.0.0",
+        "react-native-screens": ">= 3.0.0"
       }
     },
     "node_modules/@reduxjs/toolkit": {
@@ -6086,6 +6121,7 @@
       "version": "7.8.0",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-7.8.0.tgz",
       "integrity": "sha512-AmXqneQZL3KZMIgBpaPTeI6pfwh+xQ2vutMsyqOu1TBdEXFZgpG/80wuJ531w2ZN7TI0/oc8CPxzh/DKQudZqg==",
+      "deprecated": "Please update to latest patch version to fix memory leak https://github.com/isaacs/node-lru-cache/issues/227",
       "dev": true,
       "optional": true,
       "engines": {
@@ -8162,9 +8198,9 @@
       }
     },
     "node_modules/nanoid": {
-      "version": "3.3.1",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.1.tgz",
-      "integrity": "sha512-n6Vs/3KGyxPQd6uO0eH4Bv0ojGSUvuLlIHtC3Y0kEO23YRge8H9x1GCzLn28YX0H66pMkxuaeESFq4tKISKwdw==",
+      "version": "3.3.4",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.4.tgz",
+      "integrity": "sha512-MqBkQh/OHTS2egovRtLk45wEyNXwF+cokD+1YPf9u5VfJiRdAiRwB2froX5Co9Rh20xs4siNPm8naNotSD6RBw==",
       "bin": {
         "nanoid": "bin/nanoid.cjs"
       },
@@ -14148,10 +14184,19 @@
       "resolved": "https://registry.npmjs.org/@react-native/polyfills/-/polyfills-1.0.0.tgz",
       "integrity": "sha512-0jbp4RxjYopTsIdLl+/Fy2TiwVYHy4mgeu07DG4b/LyM0OS/+lPP5c9sbnt/AMlnF6qz2JRZpPpGw1eMNS6A4w=="
     },
+    "@react-navigation/bottom-tabs": {
+      "version": "https://registry.npmjs.org/@react-navigation/bottom-tabs/-/bottom-tabs-6.3.1.tgz",
+      "integrity": "sha512-sL9F4WMhhR6I9bE7bpsPVHnK1cN9doaFHAuy5YmD+Sw6OyO0TAmNgQFx4xZWqboA5ZwSkN0tWcRCr6wGXaRRag==",
+      "requires": {
+        "@react-navigation/elements": "^1.3.3",
+        "color": "^3.1.3",
+        "warn-once": "^0.1.0"
+      }
+    },
     "@react-navigation/core": {
-      "version": "6.1.1",
-      "resolved": "https://registry.npmjs.org/@react-navigation/core/-/core-6.1.1.tgz",
-      "integrity": "sha512-njysuiqztgvR1Z9Noxk2OGJfYtFGFDRyji5Vmm1jHzlql0m+q0wh1dUiyaIEtTyrhFXr/YNgdrKuiPaU9Jp8OA==",
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/@react-navigation/core/-/core-6.2.1.tgz",
+      "integrity": "sha512-3mjS6ujwGnPA/BC11DN9c2c42gFld6B6dQBgDedxP2djceXESpY2kVTTwISDHuqFnF7WjvRjsrDu3cKBX+JosA==",
       "requires": {
         "@react-navigation/routers": "^6.1.0",
         "escape-string-regexp": "^4.0.0",
@@ -14183,17 +14228,17 @@
       }
     },
     "@react-navigation/elements": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/@react-navigation/elements/-/elements-1.3.1.tgz",
-      "integrity": "sha512-jIDRJaG8YPIinl4hZXJu/W3TnhDe8hLYmGSEdL1mxZ1aoNMiApCBYkgTy11oq0EfK/koZd3DPSkJNbzBAQmPJw==",
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/@react-navigation/elements/-/elements-1.3.3.tgz",
+      "integrity": "sha512-Lv2lR7si5gNME8dRsqz57d54m4FJtrwHRjNQLOyQO546ZxO+g864cSvoLC6hQedQU0+IJnPTsZiEI2hHqfpEpw==",
       "requires": {}
     },
     "@react-navigation/native": {
-      "version": "6.0.8",
-      "resolved": "https://registry.npmjs.org/@react-navigation/native/-/native-6.0.8.tgz",
-      "integrity": "sha512-6022M3+Btok3xJC/49B88er3SRrlDAZ4FdmGndhEVvBcGSHWmscU2qKCwFd0RY6A0AGCVmdIlXudrfdcdRAkpQ==",
+      "version": "6.0.10",
+      "resolved": "https://registry.npmjs.org/@react-navigation/native/-/native-6.0.10.tgz",
+      "integrity": "sha512-H6QhLeiieGxNcAJismIDXIPZgf1myr7Og8v116tezIGmincJTOcWavTd7lPHGnMMXaZg94LlVtbaBRIx9cexqw==",
       "requires": {
-        "@react-navigation/core": "^6.1.1",
+        "@react-navigation/core": "^6.2.1",
         "escape-string-regexp": "^4.0.0",
         "fast-deep-equal": "^3.1.3",
         "nanoid": "^3.1.23"
@@ -14221,6 +14266,15 @@
       "integrity": "sha512-8xJL+djIzpFdRW/sGlKojQ06fWgFk1c5jER9501HYJ12LF5DIJFr/tqBI2TJ6bk+y+QFu0nbNyeRC80OjRlmkA==",
       "requires": {
         "nanoid": "^3.1.23"
+      }
+    },
+    "@react-navigation/stack": {
+      "version": "https://registry.npmjs.org/@react-navigation/stack/-/stack-6.2.1.tgz",
+      "integrity": "sha512-JI7boxtPAMCBXi4VJHVEq61jLVHFW5f3npvbndS+XfOsv7Gf0f91HOVJ28DS5c2Fn4+CO4AByjUozzlN296X+A==",
+      "requires": {
+        "@react-navigation/elements": "^1.3.3",
+        "color": "^3.1.3",
+        "warn-once": "^0.1.0"
       }
     },
     "@reduxjs/toolkit": {
@@ -18069,9 +18123,9 @@
       }
     },
     "nanoid": {
-      "version": "3.3.1",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.1.tgz",
-      "integrity": "sha512-n6Vs/3KGyxPQd6uO0eH4Bv0ojGSUvuLlIHtC3Y0kEO23YRge8H9x1GCzLn28YX0H66pMkxuaeESFq4tKISKwdw=="
+      "version": "3.3.4",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.4.tgz",
+      "integrity": "sha512-MqBkQh/OHTS2egovRtLk45wEyNXwF+cokD+1YPf9u5VfJiRdAiRwB2froX5Co9Rh20xs4siNPm8naNotSD6RBw=="
     },
     "nanomatch": {
       "version": "1.2.13",

--- a/native/screens/AccountSettings.jsx
+++ b/native/screens/AccountSettings.jsx
@@ -1,4 +1,5 @@
 import { useEffect, useState } from 'react';
+import { useDispatch, useSelector } from 'react-redux';
 import { Button, Text, TextInput, View } from 'react-native';
 import { confirmPassword, deleteUser, signIn, signOut } from '../services/api/users';
 import { handleTextChange, handleToggle } from '../services/utils/handlers';
@@ -6,7 +7,7 @@ import { handleTextChange, handleToggle } from '../services/utils/handlers';
 export const AccountSettings = ({ navigation, route }) => {
   const [resetPassword, toggleResetPassword] = useState(false);
   const [deleteModal, toggleDeleteModal] = useState(false);
-  const { _id: userID, email } = useSelector((state) => state.ui.user._id);
+  const { _id: userID, email } = useSelector((state) => state.ui.user);
 
   // would be a good idea to replace the modals below with a generic modal
   return (
@@ -21,8 +22,9 @@ export const AccountSettings = ({ navigation, route }) => {
 
       {resetPassword && (
         <UpdatePasswordForm
+          email={email}
           toggleResetPassword={toggleResetPassword}
-          userID={route.params.userID}
+          userID={userID}
         />
       )}
 
@@ -36,16 +38,117 @@ export const AccountSettings = ({ navigation, route }) => {
   );
 };
 
-const UpdatePasswordForm = ({ toggleResetPassword, userID }) => {
+const UpdatePasswordForm = ({ email, toggleResetPassword, userID }) => {
   const [newPasswordForm, setNewPasswordForm] = useState({
     confirmNewPassword: '',
     currentPassword: '',
     newPassword: '',
   });
+  const [rerender, toggleRerender] = useState(null);
+  const [confirmedPassword, setConfirmedPassword] = useState(null);
+  const [newPasswordsMatch, setNewPasswordMatch] = useState(false);
+  const [activeUpdateButton, setActiveUpdateButton] = useState(false);
+  const [updateStatus, setUpdateStatus] = useState('Pending');
+  const dispatch = useDispatch();
+
+  useEffect(() => {
+    setTimeout(() => {
+      if (updateStatus === 'Failed') {
+        setUpdateStatus('Pending');
+        handleTextChange('', 'currentPassword', setNewPasswordForm);
+      } else if (updateStatus === 'Success') {
+        toggleResetPassword(false);
+        setNewPasswordForm({
+          confirmNewPassword: '',
+          currentPassword: '',
+          newPassword: '',
+        });
+      }
+    }, 4000);
+  }, [toggleRerender]);
+
+  useEffect(() => {
+    setTimeout(async () => {
+      const { currentPassword, newPassword, confirmNewPassword } = newPasswordForm;
+      const credentials = {
+        email,
+        password: newPasswordForm.currentPassword,
+      };
+      const res = await confirmPassword(credentials, userID);
+      if (res) {
+        setConfirmedPassword(true);
+        if (confirmNewPassword.length > 0 && newPassword === confirmNewPassword) {
+          setNewPasswordMatch(true);
+          setActiveUpdateButton(true);
+        } else {
+          setNewPasswordMatch(false);
+        }
+      } else {
+        setConfirmedPassword(false);
+      }
+      res ? setConfirmedPassword(true) : setConfirmedPassword(false);
+      if (newPassword === confirmNewPassword) {
+        setNewPasswordMatch(true);
+      } else {
+        setNewPasswordMatch(false);
+      }
+    }, 2000);
+  }, [newPasswordForm]);
+
+  useEffect(() => {
+    if (!newPasswordsMatch && !confirmedPassword) {
+      setActiveUpdateButton(false);
+    } else {
+      setActiveUpdateButton(true);
+    }
+  }, []);
+
+  const handlePasswordUpdate = async () => {
+    const res = await updatePassword(newPassword, userID); // i feel that backend should also error check to confirm current password
+    if (res) {
+      setUpdateStatus('Success');
+      dispatch(uiActions.updateUser(res.user));
+      handleToggle(toggleRerender);
+    } else {
+      setUpdateStatus('Failed');
+    }
+  };
+
+  let UpdatePasswordStatusModal;
+  switch (updateStatus) {
+    case 'Success':
+      UpdatePasswordStatusModal = (
+        <Modal>
+          <View>
+            <Text>Password updated!</Text>
+          </View>
+        </Modal>
+      );
+      break;
+    case 'Failed':
+      UpdatePasswordStatusModal = (
+        <Modal>
+          <View>
+            <Text>Incorrect Password or !</Text>
+          </View>
+        </Modal>
+      );
+      break;
+
+    default:
+      break;
+  }
+
+  const ConfirmedPasswordMessage = ({ status }) => {
+    if (status) {
+      return <Text>Password is confirmed</Text>;
+    } else return <Text>INCORRECT PASSWORD</Text>;
+  };
 
   // this feels WET
   return (
     <View>
+      {updateStatus !== 'Pending' && UpdatePasswordStatusModal}
       <Text>Confirm your password:</Text>
       <TextInput
         onChangeText={(currPassword) =>
@@ -53,6 +156,7 @@ const UpdatePasswordForm = ({ toggleResetPassword, userID }) => {
         }
         value={newPasswordForm.currentPassword}
       />
+      {confirmedPassword !== null && <ConfirmedPasswordMessage status={confirmedPassword} />}
       <Text>Create new password:</Text>
       <TextInput
         onChangeText={(newPassword) =>
@@ -67,7 +171,16 @@ const UpdatePasswordForm = ({ toggleResetPassword, userID }) => {
         }
         value={newPasswordForm.confirmNewPassword}
       />
-      <Button title="Update my password" onPress={() => handleToggle(toggleResetPassword)} />
+
+      {newPasswordForm.newPassword !== newPasswordForm.confirmNewPassword && (
+        <Text>NEW PASSWORD AND CONFIRM NEW PASSWORD DO NOT MATCH</Text>
+      )}
+
+      <Button
+        title="Update my password"
+        disabled={!activeUpdateButton}
+        onPress={handlePasswordUpdate}
+      />
     </View>
   );
 };

--- a/native/screens/AccountSettings.jsx
+++ b/native/screens/AccountSettings.jsx
@@ -1,11 +1,62 @@
+import { useState } from 'react';
 import { Button, Text, View } from 'react-native';
+import { handleTextChange, handleToggle } from '../services/utils/handlers';
 
-export const AccountSettings = () => {
+export const AccountSettings = ({ route }) => {
+  const [resetPassword, toggleResetPassword] = useState(false);
+
   return (
     <View>
       <Text>Account Settings</Text>
-      <Text>Reset Password</Text>
+      <Button
+        title={resetPassword ? 'Cancel' : 'Reset password'}
+        onPress={() => handleToggle(toggleResetPassword)}
+      />
+
+      {resetPassword && (
+        <UpdatePasswordForm
+          toggleResetPassword={toggleResetPassword}
+          userID={route.params.userID}
+        />
+      )}
+
       <Button title="Delete Profile" />
+    </View>
+  );
+};
+
+const UpdatePasswordForm = ({ toggleResetPassword, userID }) => {
+  const [newPasswordForm, setNewPasswordForm] = useState({
+    confirmNewPassword: '',
+    currentPassword: '',
+    newPassword: '',
+  });
+
+  // this feels WET
+  return (
+    <View>
+      <Text>Confirm your password:</Text>
+      <TextInput
+        onChangeText={(currPassword) =>
+          handleTextChange(currPassword, 'currentPassword', setNewPasswordForm)
+        }
+        value={newPasswordForm.currentPassword}
+      />
+      <Text>Create new password:</Text>
+      <TextInput
+        onChangeText={(newPassword) =>
+          handleTextChange(newPassword, 'newPassword', setNewPasswordForm)
+        }
+        value={newPasswordForm.newPassword}
+      />
+      <Text>Confirm new password:</Text>
+      <TextInput
+        onChangeText={(confirmNewPassword) =>
+          handleTextChange(confirmNewPassword, 'confirmNewPassword', setNewPasswordForm)
+        }
+        value={newPasswordForm.confirmNewPassword}
+      />
+      <Button title="Update my password" onPress={() => handleToggle(toggleResetPassword)} />
     </View>
   );
 };

--- a/native/screens/AccountSettings.jsx
+++ b/native/screens/AccountSettings.jsx
@@ -1,0 +1,11 @@
+import { Button, Text, View } from 'react-native';
+
+export const AccountSettings = () => {
+  return (
+    <View>
+      <Text>Account Settings</Text>
+      <Text>Reset Password</Text>
+      <Button title="Delete Profile" />
+    </View>
+  );
+};

--- a/native/screens/AccountSettings.jsx
+++ b/native/screens/AccountSettings.jsx
@@ -1,13 +1,19 @@
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import { Button, Text, TextInput, View } from 'react-native';
+import { confirmPassword, deleteUser, signIn, signOut } from '../services/api/users';
 import { handleTextChange, handleToggle } from '../services/utils/handlers';
 
-export const AccountSettings = ({ route }) => {
+export const AccountSettings = ({ navigation, route }) => {
   const [resetPassword, toggleResetPassword] = useState(false);
+  const [deleteModal, toggleDeleteModal] = useState(false);
+  const { _id: userID, email } = useSelector((state) => state.ui.user._id);
 
+  // would be a good idea to replace the modals below with a generic modal
   return (
     <View>
       <Text>Account Settings</Text>
+
+      {deleteModal && <DeleteModal userID={userID} email={email} navigation={navigation} />}
       <Button
         title={resetPassword ? 'Cancel' : 'Reset password'}
         onPress={() => handleToggle(toggleResetPassword)}
@@ -20,7 +26,12 @@ export const AccountSettings = ({ route }) => {
         />
       )}
 
-      <Button title="Delete Profile" />
+      <Button
+        title="Delete Profile"
+        onPress={() => {
+          toggleDeleteModal(true);
+        }}
+      />
     </View>
   );
 };
@@ -58,5 +69,68 @@ const UpdatePasswordForm = ({ toggleResetPassword, userID }) => {
       />
       <Button title="Update my password" onPress={() => handleToggle(toggleResetPassword)} />
     </View>
+  );
+};
+
+const DeleteModal = ({ userID, email, navigation }) => {
+  const [deletePassword, setDeletePassword] = useState('');
+  const [deletionStatus, setDeletionStatus] = useState('Pending');
+  let ModalMessage;
+
+  useEffect(() => {
+    if (deletionStatus === 'Confirmed') {
+      signOut();
+      navigation.navigate('Landing');
+    }
+  }, [deletionStatus]);
+
+  const handleProfileDeletion = async () => {
+    const credentials = {
+      email,
+      password: deletePassword,
+    };
+    const passwordVerified = await confirmPassword({ credentials, userID });
+    if (passwordVerified) {
+      await deleteUser(userID);
+      setDeletionStatus('Confirmed');
+    } else {
+      setDeletionStatus('Unauthorized');
+    }
+  };
+
+  switch (deletionStatus) {
+    case 'Pending':
+      <View>
+        <Text>Type in your password to confirm your profile's deletion.</Text>
+        <TextInput
+          onChangeText={(confirmPassword) => {
+            setDeletePassword(confirmPassword);
+          }}
+          value={deletePassword}
+        />
+        <Button title="Delete your profile" onPress={handleProfileDeletion} />
+      </View>;
+      break;
+    case 'Confirmed':
+      <View>
+        <Text>Your Profile has been deleted.</Text>
+      </View>;
+      break;
+    case 'Unauthorized':
+      <View>
+        <Text>Incorrect password or unauthorized, please try again. </Text>
+        <Button title="OK" onPress={() => setDeletionStatus('Pending')} />
+      </View>;
+      break;
+    default:
+      <View>
+        <Text> Loading.... I shouldn't be displayed tbh</Text>;
+      </View>;
+      break;
+  }
+  return (
+    <Modal>
+      <View>{ModalMessage}</View>
+    </Modal>
   );
 };

--- a/native/screens/AccountSettings.jsx
+++ b/native/screens/AccountSettings.jsx
@@ -1,5 +1,5 @@
 import { useState } from 'react';
-import { Button, Text, View } from 'react-native';
+import { Button, Text, TextInput, View } from 'react-native';
 import { handleTextChange, handleToggle } from '../services/utils/handlers';
 
 export const AccountSettings = ({ route }) => {

--- a/native/screens/AccountSettings/AccountSettings.jsx
+++ b/native/screens/AccountSettings/AccountSettings.jsx
@@ -1,28 +1,22 @@
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import { useSelector } from 'react-redux';
 import { UpdatePasswordForm } from './UpdatePassword';
-import { DeleteModal } from './DeleteProfile';
+import { DeleteForm } from './DeleteProfile';
 import { Button, Text, View } from 'react-native';
 import { handleToggle } from '../../services/utils/handlers';
 
 export const AccountSettings = ({ navigation, route }) => {
   const [resetPassword, toggleResetPassword] = useState(false);
-  const [deleteModal, toggleDeleteModal] = useState(false);
+  const [deleteForm, toggleDeleteForm] = useState(false);
   const { _id: userID, email } = useSelector((state) => state.ui.user);
+
+  useEffect(() => {}, [resetPassword]);
 
   // would be a good idea to replace the modals below with a generic modal
   return (
     <View>
       <Text>Account Settings</Text>
 
-      {deleteModal && (
-        <DeleteModal
-          userID={userID}
-          email={email}
-          navigation={navigation}
-          toggleDeleteModal={toggleDeleteModal}
-        />
-      )}
       <Button
         title={resetPassword ? 'Cancel' : 'Reset password'}
         onPress={() => handleToggle(toggleResetPassword)}
@@ -36,19 +30,22 @@ export const AccountSettings = ({ navigation, route }) => {
         />
       )}
 
-      <Button
-        title="Delete Profile"
-        onPress={() => {
-          toggleDeleteModal(true);
-        }}
-      />
+      {deleteForm && (
+        <DeleteForm
+          userID={userID}
+          email={email}
+          navigation={navigation}
+          toggleDeleteForm={toggleDeleteForm}
+        />
+      )}
+      {!deleteForm && (
+        <Button
+          title="Delete Profile"
+          onPress={() => {
+            toggleDeleteForm(true);
+          }}
+        />
+      )}
     </View>
   );
-};
-
-// helper component
-export const ConfirmedPasswordMessage = ({ status }) => {
-  if (status) {
-    return <Text>Password is confirmed</Text>;
-  } else return <Text>INCORRECT PASSWORD</Text>;
 };

--- a/native/screens/AccountSettings/AccountSettings.jsx
+++ b/native/screens/AccountSettings/AccountSettings.jsx
@@ -1,0 +1,54 @@
+import { useState } from 'react';
+import { useSelector } from 'react-redux';
+import { Button, Text, View } from 'react-native';
+import { handleToggle } from '../../services/utils/handlers';
+import { UpdatePasswordForm } from './UpdatePassword';
+import { DeleteModal } from './DeleteProfile';
+
+export const AccountSettings = ({ navigation, route }) => {
+  const [resetPassword, toggleResetPassword] = useState(false);
+  const [deleteModal, toggleDeleteModal] = useState(false);
+  const { _id: userID, email } = useSelector((state) => state.ui.user);
+
+  // would be a good idea to replace the modals below with a generic modal
+  return (
+    <View>
+      <Text>Account Settings</Text>
+
+      {deleteModal && (
+        <DeleteModal
+          userID={userID}
+          email={email}
+          navigation={navigation}
+          toggleDeleteModal={toggleDeleteModal}
+        />
+      )}
+      <Button
+        title={resetPassword ? 'Cancel' : 'Reset password'}
+        onPress={() => handleToggle(toggleResetPassword)}
+      />
+
+      {resetPassword && (
+        <UpdatePasswordForm
+          email={email}
+          toggleResetPassword={toggleResetPassword}
+          userID={userID}
+        />
+      )}
+
+      <Button
+        title="Delete Profile"
+        onPress={() => {
+          toggleDeleteModal(true);
+        }}
+      />
+    </View>
+  );
+};
+
+// helper component
+export const ConfirmedPasswordMessage = ({ status }) => {
+  if (status) {
+    return <Text>Password is confirmed</Text>;
+  } else return <Text>INCORRECT PASSWORD</Text>;
+};

--- a/native/screens/AccountSettings/AccountSettings.jsx
+++ b/native/screens/AccountSettings/AccountSettings.jsx
@@ -1,9 +1,9 @@
 import { useState } from 'react';
 import { useSelector } from 'react-redux';
-import { Button, Text, View } from 'react-native';
-import { handleToggle } from '../../services/utils/handlers';
 import { UpdatePasswordForm } from './UpdatePassword';
 import { DeleteModal } from './DeleteProfile';
+import { Button, Text, View } from 'react-native';
+import { handleToggle } from '../../services/utils/handlers';
 
 export const AccountSettings = ({ navigation, route }) => {
   const [resetPassword, toggleResetPassword] = useState(false);

--- a/native/screens/AccountSettings/DeleteProfile.jsx
+++ b/native/screens/AccountSettings/DeleteProfile.jsx
@@ -12,10 +12,12 @@ export const DeleteForm = ({ userID, email, navigation, toggleDeleteForm }) => {
   const dispatch = useDispatch();
 
   useEffect(async () => {
-    if (deletionStatus === 'Confirmed') {
-      navigation.navigate('Landing');
-      toggleDeleteForm(false);
-    }
+    setTimeout(() => {
+      if (deletionStatus === 'Confirmed') {
+        navigation.navigate('Landing');
+        toggleDeleteForm(false);
+      }
+    }, 3000);
   }, [deletionStatus]);
 
   useEffect(() => {

--- a/native/screens/AccountSettings/DeleteProfile.jsx
+++ b/native/screens/AccountSettings/DeleteProfile.jsx
@@ -64,7 +64,7 @@ export const DeleteForm = ({ userID, email, navigation, toggleDeleteForm }) => {
       <Modal>
         <View>
           <Text>Incorrect password or unauthorized, please try again. </Text>
-          <Button title="OK" onPress={() => setDeletionStatus('Pending')} />
+          <Button title="OK" onPress={() => setDeletionStatus(null)} />
         </View>
       </Modal>
     );

--- a/native/screens/AccountSettings/DeleteProfile.jsx
+++ b/native/screens/AccountSettings/DeleteProfile.jsx
@@ -1,0 +1,98 @@
+import { useEffect, useState } from 'react';
+import { Button, Text, TextInput, Modal, View } from 'react-native';
+import { confirmPassword, deleteUser, signOut } from '../../services/api/users';
+
+export const DeleteModal = ({ userID, email, navigation, toggleDeleteModal }) => {
+  const [deletePassword, setDeletePassword] = useState('');
+  const [deletionStatus, setDeletionStatus] = useState('Pending');
+  const [confirmedPassword, setConfirmedPassword] = useState(null);
+
+  useEffect(() => {
+    if (deletionStatus === 'Confirmed') {
+      signOut();
+      navigation.navigate('Landing');
+      toggleDeleteModal(false);
+    }
+  }, [deletionStatus]);
+
+  useEffect(() => {
+    if (deletePassword.length > 3) {
+      setTimeout(() => {
+        const credentials = {
+          email,
+          password: deletePassword,
+        };
+        setConfirmedPassword(async () => {
+          return await confirmPassword({ credentials, userID });
+        });
+      }, 2000);
+    } else {
+      setConfirmedPassword(null);
+    }
+  }, [deletePassword]);
+
+  const handleProfileDeletion = async () => {
+    if (confirmedPassword) {
+      await deleteUser(userID);
+      setDeletionStatus('Confirmed');
+    } else {
+      setDeletionStatus('Unauthorized');
+    }
+  };
+
+  let ModalMessage;
+  switch (deletionStatus) {
+    case 'Pending':
+      ModalMessage = (
+        <View>
+          <Button
+            title="Cancel Deletion"
+            onPress={() => {
+              toggleDeleteModal(false);
+            }}
+          />
+          <Text>Type in your password to confirm your profile's deletion.</Text>
+          <TextInput
+            autoCapitalize="none"
+            returnKeyType="next"
+            secureTextEntry={true}
+            onChangeText={(confirmPassword) => {
+              setDeletePassword(confirmPassword);
+            }}
+            value={deletePassword}
+          />
+          {confirmedPassword !== null && <ConfirmedPasswordMessage status={confirmedPassword} />}
+          <Button
+            disabled={!confirmedPassword}
+            title="Delete your profile"
+            onPress={handleProfileDeletion}
+          />
+        </View>
+      );
+      break;
+    case 'Confirmed':
+      ModalMessage = (
+        <View>
+          <Text>Your Profile has been deleted.</Text>
+        </View>
+      );
+      break;
+    case 'Unauthorized':
+      ModalMessage = (
+        <View>
+          <Text>Incorrect password or unauthorized, please try again. </Text>
+          <Button title="OK" onPress={() => setDeletionStatus('Pending')} />
+        </View>
+      );
+      break;
+    default:
+      ModalMessage = (
+        <View>
+          <Text> Loading.... I shouldn't be displayed tbh</Text>;
+        </View>
+      );
+      break;
+  }
+
+  return <Modal>{ModalMessage}</Modal>;
+};

--- a/native/screens/AccountSettings/Helpers.jsx
+++ b/native/screens/AccountSettings/Helpers.jsx
@@ -1,0 +1,6 @@
+import { Text } from 'react-native';
+export const ConfirmedPasswordMessage = ({ status }) => {
+  if (status) {
+    return <Text>Password is confirmed</Text>;
+  } else return <Text>INCORRECT PASSWORD</Text>;
+};

--- a/native/screens/AccountSettings/UpdatePassword.jsx
+++ b/native/screens/AccountSettings/UpdatePassword.jsx
@@ -1,6 +1,7 @@
 import { useEffect, useState } from 'react';
 import { useDispatch } from 'react-redux';
 import { Button, Text, TextInput, Modal, View } from 'react-native';
+import { ConfirmedPasswordMessage } from './Helpers';
 import { confirmPassword, updatePassword } from '../../services/api/users';
 import { uiActions } from '../../services/redux/slices/uiSlice';
 import { handleTextChange, handleToggle } from '../../services/utils/handlers';
@@ -24,6 +25,7 @@ export const UpdatePasswordForm = ({ email, toggleResetPassword, userID }) => {
         setUpdateStatus('Pending');
         handleTextChange('', 'currentPassword', setNewPasswordForm);
       } else if (updateStatus === 'Success') {
+        setUpdateStatus(null);
         toggleResetPassword(false);
         setNewPasswordForm({
           confirmNewPassword: '',
@@ -36,7 +38,7 @@ export const UpdatePasswordForm = ({ email, toggleResetPassword, userID }) => {
 
   useEffect(() => {
     const { currentPassword, newPassword, confirmNewPassword } = newPasswordForm;
-    if (currentPassword.length > 0) {
+    if (currentPassword.length > 3) {
       setTimeout(async () => {
         const credentials = {
           email,
@@ -80,6 +82,7 @@ export const UpdatePasswordForm = ({ email, toggleResetPassword, userID }) => {
       setUpdateStatus('Success');
       dispatch(uiActions.updateUser(res.user));
       handleToggle(toggleRerender);
+      toggleResetPassword(false);
     } else {
       setUpdateStatus('Failed');
     }

--- a/native/screens/Settings.jsx
+++ b/native/screens/Settings.jsx
@@ -1,9 +1,18 @@
+import { useDispatch, useSelector } from 'react-redux';
 import { Text, Button, View } from 'react-native';
-import { useSelector } from 'react-redux';
+import { signOut } from '../services/api/users';
+import { uiActions } from '../services/redux/slices/uiSlice';
 
 export const Settings = ({ navigation }) => {
   const reduxUser = useSelector((state) => state.ui.user);
   const { _id: userID, first_name, last_name } = reduxUser;
+  const dispatch = useDispatch();
+
+  const handleLogout = async () => {
+    await signOut();
+    dispatch(uiActions.resetUser());
+    navigation.navigate('Landing');
+  };
 
   return (
     <View>
@@ -24,7 +33,7 @@ export const Settings = ({ navigation }) => {
           onPress={() => navigation.navigate('AccountSettings', { userID })}
         />
       </View>
-      <Button title="Log Out" />
+      <Button title="Log Out" onPress={handleLogout} />
     </View>
   );
 };

--- a/native/screens/Settings.jsx
+++ b/native/screens/Settings.jsx
@@ -8,7 +8,7 @@ export const Settings = ({ navigation }) => {
   const { _id: userID, first_name, last_name } = reduxUser;
   const dispatch = useDispatch();
 
-  const handleLogout = async () => {
+  const handleSignOut = async () => {
     await signOut();
     dispatch(uiActions.resetUser());
     navigation.navigate('Landing');
@@ -33,7 +33,7 @@ export const Settings = ({ navigation }) => {
           onPress={() => navigation.navigate('AccountSettings', { userID })}
         />
       </View>
-      <Button title="Log Out" onPress={handleLogout} />
+      <Button title="Log Out" onPress={handleSignOut} />
     </View>
   );
 };

--- a/native/screens/Settings.jsx
+++ b/native/screens/Settings.jsx
@@ -1,5 +1,4 @@
-import { useEffect } from 'react';
-import { Button, View } from 'react-native';
+import { Text, Button, View } from 'react-native';
 import { useSelector } from 'react-redux';
 
 export const Settings = ({ navigation }) => {
@@ -13,7 +12,6 @@ export const Settings = ({ navigation }) => {
         <Text>User Image</Text>
         <Text>{`${first_name} ${last_name}`}</Text>
       </View>
-      {/* list of options */}
       <View>
         <Text>Setting 1</Text>
         <Text>Setting 2</Text>
@@ -23,7 +21,7 @@ export const Settings = ({ navigation }) => {
         />
         <Button
           title="Account Settings"
-          onPress={() => navigation.navigate('Account Settings', { userID })}
+          onPress={() => navigation.navigate('AccountSettings', { userID })}
         />
       </View>
       <Button title="Log Out" />

--- a/native/screens/Settings.jsx
+++ b/native/screens/Settings.jsx
@@ -1,0 +1,32 @@
+import { useEffect } from 'react';
+import { Button, View } from 'react-native';
+import { useSelector } from 'react-redux';
+
+export const Settings = ({ navigation }) => {
+  const reduxUser = useSelector((state) => state.ui.user);
+  const { _id: userID, first_name, last_name } = reduxUser;
+
+  return (
+    <View>
+      <Text>Settings</Text>
+      <View>
+        <Text>User Image</Text>
+        <Text>{`${first_name} ${last_name}`}</Text>
+      </View>
+      {/* list of options */}
+      <View>
+        <Text>Setting 1</Text>
+        <Text>Setting 2</Text>
+        <Button
+          title="Edit Profile"
+          onPress={() => navigation.navigate('EditProfile', { userID })}
+        />
+        <Button
+          title="Account Settings"
+          onPress={() => navigation.navigate('Account Settings', { userID })}
+        />
+      </View>
+      <Button title="Log Out" />
+    </View>
+  );
+};

--- a/native/screens/UserProfile.jsx
+++ b/native/screens/UserProfile.jsx
@@ -57,7 +57,17 @@ export const UserProfile = ({ route, navigation }) => {
 
   useEffect(() => {
     const setUser = async () => {
-      if (!route.params || route.params.userID === reduxUser._id) {
+      if (!route.params && !reduxUser) {
+        setCurrUser({
+          first_name: 'NO',
+          last_name: 'USER',
+          role: '',
+          email: '',
+          about: '',
+          fun_fact: '',
+          portfolio_link: '',
+        });
+      } else if (!route.params || route.params.userID === reduxUser._id) {
         setCurrUser(reduxUser);
       } else {
         const res = await getOneUser(route.params.userID); // must be tested
@@ -66,7 +76,7 @@ export const UserProfile = ({ route, navigation }) => {
       dispatch(uiActions.toggleEditMode());
     };
     setUser();
-  }, [route.params]);
+  }, [route.params, reduxUser]);
 
   const handleEditMode = () => {
     dispatch(uiActions.toggleEditMode(true));

--- a/native/services/api/users.js
+++ b/native/services/api/users.js
@@ -117,7 +117,8 @@ export const confirmPassword = async (credentials, userID) => {
 };
 
 export const updatePassword = async (newPassword, userID) => {
-  const { message, status, token, user } = api.post(`/update-password/${userID}`, { newPassword });
+  const res = await api.patch(`/update-password/${userID}`, { newPassword });
+  const { message, status, token, user } = res.data;
   if (status) {
     await SecureStore.setItemAsync('token', token);
     return { status, user };

--- a/native/services/api/users.js
+++ b/native/services/api/users.js
@@ -31,6 +31,7 @@ export const updateUser = async (id, userUpdate) => {
 export const deleteUser = async (id) => {
   try {
     const res = await api.delete(`/users/${id}`);
+    const token = await SecureStore.deleteItemAsync('token', token);
     return res.data;
   } catch (error) {
     throw error;
@@ -62,7 +63,7 @@ export const signUp = async (credentials) => {
     SecureStore.setItemAsync('token', token);
     return user;
   } catch (error) {
-    console.log(
+    console.error(
       'Error: Unsuccessful sign-up. Verify that you do not have empty fields and a valid email.'
     );
     console.error(error);
@@ -74,11 +75,11 @@ export const signIn = async (credentials) => {
   try {
     const res = await api.post('/sign-in', credentials);
     const { token, user } = res.data;
-    SecureStore.setItemAsync('token', token);
+    await SecureStore.setItemAsync('token', token);
     // const user = jwtDecode(res.data.token);
     return user;
   } catch (error) {
-    console.log('Error: User credentials incorrect or user does not exist.');
+    console.error('Error: User credentials incorrect or user does not exist.');
     console.error(error);
     return false;
   }
@@ -98,7 +99,7 @@ export const verify = async () => {
   const token = await SecureStore.getItemAsync('token');
   if (token) {
     const { data: payload } = await api.get('/verify');
-    const { data: user } = await api.get(`/users/${payload.id}`);
+    const { data: user } = await api.get(`/users/${payload.userID}`);
     return user;
   }
   return false;
@@ -111,7 +112,7 @@ export const confirmPassword = async (credentials, userID) => {
     const { data: passwordConfirmed } = await api.post(`/confirm-password/${userID}`, credentials);
     return passwordConfirmed;
   } catch (error) {
-    console.log(error);
+    console.error(error);
     return false;
   }
 };
@@ -123,7 +124,7 @@ export const updatePassword = async (newPassword, userID) => {
     await SecureStore.setItemAsync('token', token);
     return { status, user };
   } else {
-    console.log('API Error:', message);
+    console.error('API Error:', message);
     return false;
   }
 };

--- a/native/services/api/users.js
+++ b/native/services/api/users.js
@@ -28,6 +28,15 @@ export const updateUser = async (id, userUpdate) => {
   }
 };
 
+export const deleteUser = async (id) => {
+  try {
+    const res = await api.delete(`/users/${id}`);
+    return res.data;
+  } catch (error) {
+    throw error;
+  }
+};
+
 export const addPortfolioProject = async (id, newProject) => {
   try {
     const res = await api.patch(`/users/${id}`, newProject);
@@ -93,4 +102,12 @@ export const verify = async () => {
     return user;
   }
   return false;
+};
+
+// tokens may be different every time the JWT formula is used
+// foolproof this solution
+export const confirmPassword = async (credentials, userID) => {
+  const secureStoreToken = await SecureStore.getItemAsync('token');
+  const backendToken = api.post(`/confirmPassword/${userID}`, credentials);
+  return secureStoreToken === backendToken ? true : false;
 };

--- a/native/services/api/users.js
+++ b/native/services/api/users.js
@@ -107,7 +107,22 @@ export const verify = async () => {
 // tokens may be different every time the JWT formula is used
 // foolproof this solution
 export const confirmPassword = async (credentials, userID) => {
-  const secureStoreToken = await SecureStore.getItemAsync('token');
-  const backendToken = api.post(`/confirmPassword/${userID}`, credentials);
-  return secureStoreToken === backendToken ? true : false;
+  try {
+    const { data: passwordConfirmed } = await api.post(`/confirm-password/${userID}`, credentials);
+    return passwordConfirmed;
+  } catch (error) {
+    console.log(error);
+    return false;
+  }
+};
+
+export const updatePassword = async (newPassword, userID) => {
+  const { message, status, token, user } = api.post(`/update-password/${userID}`, { newPassword });
+  if (status) {
+    await SecureStore.setItemAsync('token', token);
+    return { status, user };
+  } else {
+    console.log('API Error:', message);
+    return false;
+  }
 };

--- a/native/services/redux/slices/uiSlice.js
+++ b/native/services/redux/slices/uiSlice.js
@@ -57,6 +57,9 @@ export const uiSlice = createSlice({
         ];
       }
     },
+    resetUser(state) {
+      state.user = '';
+    },
   },
 });
 


### PR DESCRIPTION
This PR will:
- Create a `Settings` and `AccountSettings` screen
- `Settings` will be capable of logging the user out & navigating the user to EditProfile + AccountSettings
- `AccountSettings` comes with the creation of 2 backend API's: `confirmPassword` & `updatePassword` with the corresponding logic on the front-end
- It also includes some minor updates to functions in `helpers.js` as well as cleaning up some stale code, particularly in `App.js`

CONCERNS:
- There is a memory link in one of the useEffects within AccountSettings: `This is a no-op cannot perform on an unmounted component......`  this can be potentially handled with <a href="https://www.linkedin.com/feed/update/urn:li:activity:6933399770535260160/" target="_blank"> this LinkedIn post </a> but I haven't had the time to test it out

Thanks for reviewing this, this is a reminder that you rock!! 