### PR TITLE
Refactor/bc 224 migrate user profile screen

### DIFF
--- a/client/src/assets/fonts.css
+++ b/client/src/assets/fonts.css
@@ -1,1 +1,1 @@
-@import url('https://fonts.googleapis.com/css2?family=Inter&family=Nunito:wght@500;600;700&display=swap');
+@import url('https://fonts.googleapis.com/css2?family=Inter&family=Nunito:wght@200;400;500;600;700&display=swap');

--- a/client/src/screens/UserProfile/UserProfile.jsx
+++ b/client/src/screens/UserProfile/UserProfile.jsx
@@ -5,10 +5,10 @@ import { useParams } from 'react-router-dom';
 import { ShowPortfolioProjects } from '../../components/Projects/PortfolioCard/PortfolioCard';
 import { EditProfile } from '../EditProfile/EditProfile';
 // assets
-import { uiActions } from '../../services/redux/slices/uiSlice';
 import './UserProfile.scss';
+import { BiPencil } from 'react-icons/bi';
+import { uiActions } from '../../services/redux/slices/uiSlice';
 import { getOneUser } from '../../services/api/users';
-import { Header } from '../../components/Header/Header';
 
 export const UserProfile = () => {
   const { user: reduxUser, editMode } = useSelector((state) => state.ui);
@@ -56,16 +56,23 @@ export const UserProfile = () => {
       <div className="user-profile">
         <header>PROFILE</header>
         <div className="contact">
-          <p>
-            EDIT <br /> PENCIL
-          </p>
-          <p>IMAGE</p>
-          <p>FIRST/LAST NAME</p>
-          <p>TITLE</p>
-          <div className="media">
-            <div>X</div>
-            <div>X</div>
-            <div>X</div>
+          <div className="contact-left">
+            <div className="toggle-edit">
+              <BiPencil size={25} />
+            </div>
+            <div className="image"></div>
+          </div>
+
+          <div className="contact-right">
+            <div>
+              <p className="name">FIRST/LAST NAME</p>
+              <p className="role">TITLE</p>
+            </div>
+            <div className="media">
+              <div>X</div>
+              <div>X</div>
+              <div>X</div>
+            </div>
           </div>
         </div>
 

--- a/client/src/screens/UserProfile/UserProfile.jsx
+++ b/client/src/screens/UserProfile/UserProfile.jsx
@@ -7,6 +7,7 @@ import { EditProfile } from '../EditProfile/EditProfile';
 // assets
 import './UserProfile.scss';
 import { BiPencil } from 'react-icons/bi';
+import { BsBriefcaseFill, BsGithub, BsLinkedin } from 'react-icons/bs';
 import { uiActions } from '../../services/redux/slices/uiSlice';
 import { getOneUser } from '../../services/api/users';
 
@@ -65,13 +66,15 @@ export const UserProfile = () => {
 
           <div className="contact-right">
             <div>
-              <p className="name">FIRST/LAST NAME</p>
-              <p className="role">TITLE</p>
+              <p className="name">
+                {first_name} {last_name}
+              </p>
+              <p className="role">{role}</p>
             </div>
             <div className="media">
-              <div>X</div>
-              <div>X</div>
-              <div>X</div>
+              <BsGithub size={25} />
+              <BsLinkedin size={25} />
+              <BsBriefcaseFill size={25} />
             </div>
           </div>
         </div>

--- a/client/src/screens/UserProfile/UserProfile.jsx
+++ b/client/src/screens/UserProfile/UserProfile.jsx
@@ -64,7 +64,7 @@ export const UserProfile = () => {
         <div className="contact">
           <div className="contact-left">
             <div className="toggle-edit">
-              <BiPencil size={25} />
+              <BiPencil size={25} onClick={handleToggleMode} />
             </div>
             <div className="image"></div>
           </div>
@@ -77,9 +77,9 @@ export const UserProfile = () => {
               <p className="role">{role}</p>
             </div>
             <div className="media">
-              <SiMaildotru size={30} onClick={sendEmail} />
-              <BsLinkedin size={25} />
-              <BsBriefcaseFill size={25} onClick={routeToPortfolio} />
+              <SiMaildotru style={{ cursor: 'pointer' }} size={30} onClick={sendEmail} />
+              <BsLinkedin style={{ cursor: 'pointer' }} size={25} />
+              <BsBriefcaseFill style={{ cursor: 'pointer' }} size={25} onClick={routeToPortfolio} />
             </div>
           </div>
         </div>

--- a/client/src/screens/UserProfile/UserProfile.jsx
+++ b/client/src/screens/UserProfile/UserProfile.jsx
@@ -8,17 +8,18 @@ import { EditProfile } from '../EditProfile/EditProfile';
 import { uiActions } from '../../services/redux/slices/uiSlice';
 import './UserProfile.scss';
 import { getOneUser } from '../../services/api/users';
+import { Header } from '../../components/Header/Header';
 
 export const UserProfile = () => {
   const { user: reduxUser, editMode } = useSelector((state) => state.ui);
   const [currUser, setCurrUser] = useState({
-    first_name: '',
-    last_name: '',
-    role: '',
-    email: '',
     about: '',
+    email: '',
+    first_name: '',
     fun_fact: '',
+    last_name: '',
     portfolio_link: '',
+    role: '',
   });
   const dispatch = useDispatch();
   const params = useParams();
@@ -39,6 +40,8 @@ export const UserProfile = () => {
   const handleToggleMode = () => {
     dispatch(uiActions.toggleEditMode());
   };
+  const AboutUser = () => <p>{currUser.about}</p>;
+  const FunFact = () => <p>{currUser.fun_fact}</p>;
 
   if (editMode) {
     return (
@@ -51,40 +54,34 @@ export const UserProfile = () => {
     const { about, email, fun_fact, first_name, last_name, role, _id: currUserId } = currUser;
     return (
       <div className="user-profile">
-        <div className="title-wrapper">
-          {currUserId === reduxUser._id && <button onClick={handleToggleMode}>edit profile</button>}
-          <h2 className="title-name">
-            {first_name} {last_name}
-          </h2>
-          <h2 className="title-role">{role}</h2>
-        </div>
-        <div className="image">im an image</div>
-
-        <div className="links">
-          <a href={`mailto:${email}`} target="">
-            E-mail
-          </a>
-          <a href={validUrl} target="_blank">
-            Portfolio
-          </a>
-        </div>
-
-        <div className="content">
-          <div className="about">
-            <h3>About</h3>
-            <p>{about}</p>
+        <header>PROFILE</header>
+        <div className="contact">
+          <p>
+            EDIT <br /> PENCIL
+          </p>
+          <p>IMAGE</p>
+          <p>FIRST/LAST NAME</p>
+          <p>TITLE</p>
+          <div className="media">
+            <div>X</div>
+            <div>X</div>
+            <div>X</div>
           </div>
-
-          {fun_fact && (
-            <div className="fun-fact">
-              <h3>Fun Fact</h3>
-              <p>{fun_fact}</p>
-            </div>
-          )}
         </div>
 
-        <ShowPortfolioProjects currUser={currUser} />
+        <InfoCard header="about user" children={<AboutUser />} />
+        <InfoCard header="fun fact" children={<FunFact />} />
+        <InfoCard header="portfolio" children={<ShowPortfolioProjects currUser={currUser} />} />
       </div>
     );
   }
+};
+
+const InfoCard = ({ children, header }) => {
+  return (
+    <div className="info-card">
+      <h4>{header}</h4>
+      {children}
+    </div>
+  );
 };

--- a/client/src/screens/UserProfile/UserProfile.jsx
+++ b/client/src/screens/UserProfile/UserProfile.jsx
@@ -8,6 +8,7 @@ import { EditProfile } from '../EditProfile/EditProfile';
 import './UserProfile.scss';
 import { BiPencil } from 'react-icons/bi';
 import { BsBriefcaseFill, BsGithub, BsLinkedin } from 'react-icons/bs';
+import { SiMaildotru } from 'react-icons/si';
 import { uiActions } from '../../services/redux/slices/uiSlice';
 import { getOneUser } from '../../services/api/users';
 
@@ -25,6 +26,7 @@ export const UserProfile = () => {
   const dispatch = useDispatch();
   const params = useParams();
   const validUrl = `http://${reduxUser.portfolio_link}`;
+  const { about, email, fun_fact, first_name, last_name, role } = currUser;
 
   useEffect(() => {
     const setUser = async () => {
@@ -41,8 +43,12 @@ export const UserProfile = () => {
   const handleToggleMode = () => {
     dispatch(uiActions.toggleEditMode());
   };
-  const AboutUser = () => <p>{currUser.about}</p>;
-  const FunFact = () => <p>{currUser.fun_fact}</p>;
+
+  const sendEmail = () => (window.location = `mailto:${email}`);
+  const routeToPortfolio = () => window.open(validUrl, '_blank');
+
+  const AboutUser = () => <p>{about}</p>;
+  const FunFact = () => <p>{fun_fact}</p>;
 
   if (editMode) {
     return (
@@ -52,10 +58,9 @@ export const UserProfile = () => {
       </>
     );
   } else {
-    const { about, email, fun_fact, first_name, last_name, role, _id: currUserId } = currUser;
     return (
       <div className="user-profile">
-        <header>PROFILE</header>
+        <header>Profile</header>
         <div className="contact">
           <div className="contact-left">
             <div className="toggle-edit">
@@ -72,9 +77,9 @@ export const UserProfile = () => {
               <p className="role">{role}</p>
             </div>
             <div className="media">
-              <BsGithub size={25} />
+              <SiMaildotru size={30} onClick={sendEmail} />
               <BsLinkedin size={25} />
-              <BsBriefcaseFill size={25} />
+              <BsBriefcaseFill size={25} onClick={routeToPortfolio} />
             </div>
           </div>
         </div>

--- a/client/src/screens/UserProfile/UserProfile.scss
+++ b/client/src/screens/UserProfile/UserProfile.scss
@@ -1,8 +1,41 @@
 .user-profile {
+  align-items: center;
   display: flex;
   flex-direction: column;
   justify-content: center;
-  align-items: center;
+
+  .contact {
+    display: flex;
+    justify-content:space-around;
+    padding: 10px;
+    width: 100%;
+  }
+  
+  .contact-left {
+    position: relative;
+  }
+
+  .toggle-edit {
+    align-items: center;
+    background-color: #fff;
+    border: 2px solid #000;
+    border-radius: 100%;
+    bottom: 0;
+    display: flex;
+    justify-content: center;
+    height: 40px;
+    position: absolute;
+    right: 0;
+    width: 40px;
+  }
+  
+  .image {
+    background-color: #c4c4c4;
+    border-radius: 100%;
+    height: 140px;
+    margin: auto;
+    width: 140px;
+  }
 }
 
 .info-card {

--- a/client/src/screens/UserProfile/UserProfile.scss
+++ b/client/src/screens/UserProfile/UserProfile.scss
@@ -6,13 +6,16 @@
 
   .contact {
     display: flex;
-    justify-content:space-around;
+    flex: 40px 1;
+    justify-content: space-between; 
     padding: 10px;
     width: 100%;
   }
   
+  // Left side of user contact
   .contact-left {
     position: relative;
+    width: 40%;
   }
 
   .toggle-edit {
@@ -32,9 +35,39 @@
   .image {
     background-color: #c4c4c4;
     border-radius: 100%;
-    height: 140px;
+    height: 120px;
     margin: auto;
-    width: 140px;
+    width: 120px;
+  }
+
+  // Right side of user contact
+  .contact-right {
+    display: flex;
+    flex-direction: column;
+    justify-content: space-evenly;
+    text-align: center;
+  }
+
+  .name {
+    font-size: 24px;
+    font-weight: 600;
+    text-transform: capitalize;
+  }
+  
+  .role {
+    font-size: 18px;
+  }
+
+  .media {
+    display: flex;
+    justify-content: space-evenly;
+    margin-top: 10px;
+
+    div {
+      background-color: #d9d9d9;
+      height: 30px;
+      width: 30px;
+    }
   }
 }
 

--- a/client/src/screens/UserProfile/UserProfile.scss
+++ b/client/src/screens/UserProfile/UserProfile.scss
@@ -30,6 +30,7 @@
     border: 2px solid #000;
     border-radius: 100%;
     bottom: 0;
+    cursor: pointer;
     display: flex;
     justify-content: center;
     height: 40px;
@@ -68,7 +69,7 @@
     display: flex;
     justify-content: space-evenly;
     margin-top: 10px;
-
+    
     div {
       background-color: #d9d9d9;
       height: 30px;

--- a/client/src/screens/UserProfile/UserProfile.scss
+++ b/client/src/screens/UserProfile/UserProfile.scss
@@ -32,8 +32,8 @@
     bottom: 0;
     cursor: pointer;
     display: flex;
-    justify-content: center;
     height: 40px;
+    justify-content: center;
     position: absolute;
     right: 0;
     width: 40px;

--- a/client/src/screens/UserProfile/UserProfile.scss
+++ b/client/src/screens/UserProfile/UserProfile.scss
@@ -4,18 +4,24 @@
   flex-direction: column;
   justify-content: center;
 
+  header {
+    font-size: 24px;
+    font-weight: 600;
+    margin-top: 10px;
+  }
+
   .contact {
     display: flex;
     flex: 40px 1;
     justify-content: space-between; 
     padding: 10px;
+    margin-bottom: 30px;
     width: 100%;
   }
   
   // Left side of user contact
   .contact-left {
     position: relative;
-    width: 40%;
   }
 
   .toggle-edit {
@@ -35,9 +41,9 @@
   .image {
     background-color: #c4c4c4;
     border-radius: 100%;
-    height: 120px;
+    height: 125px;
     margin: auto;
-    width: 120px;
+    width: 125px;
   }
 
   // Right side of user contact

--- a/client/src/screens/UserProfile/UserProfile.scss
+++ b/client/src/screens/UserProfile/UserProfile.scss
@@ -1,45 +1,22 @@
 .user-profile {
-  .title-wrapper {
-    margin-top: 1rem;
-    text-align: center;
-    .title-name {
-      font-size: 2rem;
-      text-decoration: underline;
-    }
-    .title-role {
-      font-weight: 400;
-    }
-  }
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+}
 
-  .image {
-    background-color: gray;
-    height: 150px;
-    margin: 1rem auto 0;
-    width: 150px;
-  }
+.info-card {
+  background-color: #313131;
+  border-radius: 4px;
+  color: white;
+  font-weight: 300;
+  margin-bottom: 20px;
+  padding: 10px;
+  width: 300px;
 
-  .links {
-    display: flex;
-    font-size: 1rem;
-    justify-content: space-between;
-    margin: 1rem auto;
-    width: 200px;
-    a {
-      color: black;
-    }
-  }
-
-  .content {
-    margin: auto;
-    width: 300px;
-    h3 {
-      font-weight: 100;
-      font-size: 1.5rem;
-      text-decoration: underline;
-    }
-    p {
-      margin: 0.5rem 0 0.5rem 2.5rem;
-      width: 250px;
-    }
+  h4 {
+    font-weight: 700;
+    margin-bottom: 5px;
+    text-transform: uppercase;
   }
 }


### PR DESCRIPTION
Accomplishes [BC-224: Migrate user profile screen](https://bootcamper.atlassian.net/browse/BC-224?atlOrigin=eyJpIjoiMzRhNTM1ZDZkMWMwNGJlMTk3NWFkOTUxMTRkZmQ2NTMiLCJwIjoiaiJ9)
- [x] Looks visually similar to the figma (I made a judgement call on the profile card that iI'm not committed to after the fact)
- [x] Black wrapper card is reusable for any other tiles we might place there
- [x] Links to website, email, edit profile
  - [ ]  User model does not yet have a property for linkedin
- [ ]  ShowPortfolioProjects will be its own ticket with the rest of the associated components and is the only element missing from this screen 